### PR TITLE
Update API-design-guidelines.md with typo fix of pr257 in comm-wg

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -622,7 +622,7 @@ In the following, we ellaborate on the exisiing client errors. In particular, we
 
 | **Error code** | Description |
 |-----|-----|
-|`INVALID ARGUMENT` |  A specified resource duplicate entry found. |
+|`INVALID_ARGUMENT` |  A specified resource duplicate entry found. |
 |`CONFLICT` |  A specified resource duplicate entry found. |
 |`OUT_OF_RANGE`| Client specified an invalid range. |
 |`PERMISSION_DENIED`|  Client does not have sufficient permissions to perform this action. |


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:
redo typo fix done in comm wg pr 257

#### Which issue(s) this PR fixes:

Fixes #19 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
