### PR TITLE
Define CAMARA Event using cloudevents in OAS notification

### DIFF
--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -190,10 +190,6 @@ components:
         data:
           type: object
           description: Event details payload described in each CAMARA API and referenced by its type
-        subject:
-          description: Describes the subject of the event in the context of the event producer (identified by source).
-          type: string
-          example: ROAMING
         time:
           $ref: "#/components/schemas/DateTime"
 

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -47,8 +47,8 @@ externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 security:
-  - oAuth2ClientCredentials: []
-  - {}
+    - notificationsBearerAuth: []
+    - {}
 
 servers:
   - url: '{apiRoot}'
@@ -114,12 +114,10 @@ paths:
           $ref: "#/components/responses/Generic503"
 components:
   securitySchemes:
-    oAuth2ClientCredentials:
-      type: oauth2
-      flows:
-        clientCredentials:
-          tokenUrl: '{tokenUrl}'
-          scopes: {}
+    notificationsBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: "{$request.body#/webhook/notificationAuthToken}"
   schemas:
     ErrorInfo:
       type: object

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -8,7 +8,7 @@ info:
 
     A lot of CAMARA APIs offer the capability to API consumer to receive events.
     Event data are defined in each API definition but in order to provide consistency across CAMARA APIs and to increase 
-    interoperability we will use [cloudevents](https://cloudevents.io/) specifications. In particular, CAMARA Event will 
+    interoperability we will use [cloudevents](https://cloudevents.io/) specifications. In particular, every CAMARA Event will 
     be defined using [cloudevents-json-format](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)
    
     # Relevant terms and definitions

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -177,8 +177,8 @@ components:
           $ref: '#/components/schemas/Source'
         type:
           type: string
-          description: 'type of event as defined in each CAMARA API (e.g.: org.camara.qod.qos-status-changed-event)'
-          example: org.camara.qod.qos-status-changed-event
+          description: 'type of event as defined in each CAMARA API (e.g.: org.camaraproject.qod.qos-status-changed-event)'
+          example: org.camaraproject.qod.qos-status-changed-event
           minLength: 15
         specversion:
           type: string
@@ -280,7 +280,7 @@ components:
       value:
         id: 123e4567-e89b-12d3-a456-426655440000
         source: com.orange.camara.qod
-        type: org.camara.qod.qos-status-changed-event
+        type: org.camaraproject.qod.qos-status-changed-event
         specversion: '1.0'
         time: 2023-01-17T13:18:23.682Z
         datacontenttype: application/json

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -31,14 +31,14 @@ info:
       * **Data**:  Domain-specific information about the occurrence (i.e. the payload). This might 
     include information about the occurrence, details about the data that was changed, or more.
   
+    # API Functionality
     
-    # API Functionality   
-      
     Only one endpoint/operation is provided: `POST /your_webhook_notification_url`
-    
     This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
   
-  
+    # Security
+    
+    Security is the responsibility of the API provider. The API provider must include its requirements in the security section of this specification or remove this section if it does not support any authentication scheme.
 
   termsOfService: http://swagger.io/terms/
   contact:
@@ -46,7 +46,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-wip
+  version: 0.1.0
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
@@ -57,7 +57,7 @@ servers:
   - url: '{apiRoot}'
     variables:
       apiRoot:
-        default: http://localhost:8080
+        default: https://localhost:8080
         description: Can be any notification server address sent by the client application
 tags:
   - name: Cloud Event
@@ -145,7 +145,9 @@ components:
     DateTime:
       type: string
       format: date-time
-      description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+      description: |
+        Timestamp of when the occurrence happened. Must adhere to RFC 3339. 
+        WARN: This optional field in CloudEvents specification is required in CAMARA APIs implementation.
       example: '2018-04-05T17:31:00Z'
 
     Source:
@@ -179,7 +181,7 @@ components:
           type: string
           description: 'type of event as defined in each CAMARA API (e.g.: org.camaraproject.qod.qos-status-changed-event)'
           example: org.camaraproject.qod.qos-status-changed-event
-          minLength: 15
+          minLength: 25
         specversion:
           type: string
           description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -151,13 +151,17 @@ components:
       format: uri-reference
       minLength: 1
       description: "Identifies the context in which an event happened - be a non-empty `URI-reference."
-      example:
-        - https://github.com/cloudevents
-        - mailto:cncf-wg-serverless@lists.cncf.io
-        - urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
-        - cloudevents/spec/pull/123
-        - /sensors/tn-1234567/alerts
-        - 1-555-123-4567
+     examples:
+        absolute_uri_https:
+          value: https://github.com/cloudevents
+        absolute_uri_mailto:
+          value: mailto:cncf-wg-serverless@lists.cncf.io
+        URN_with_UUID:
+          value: urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+        application_specific_relative_reference:
+          value: /cloudevents/spec/pull/123
+        application_specific:
+          value: 1-555-123-4567
 
     CloudEvent:
       description: The notification callback

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -6,7 +6,7 @@ info:
 
     # Introduction
 
-    A lot of CAMARA APIs offer the capability to consumer to receive event.
+    A lot of CAMARA APIs offer the capability to API consumer to receive events.
     Event data are defined in each API definition but in order to provide consistency across CAMARA APIs and to increase 
     interoperability we will use [cloudevents](https://cloudevents.io/) specifications. In particular, CAMARA Event will 
     be defined using [cloudevents-json-format](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -277,7 +277,7 @@ components:
     QOS_STATUS_CHANGED_EXAMPLE:
       value:
         id: "123e4567-e89b-12d3-a456-426655440000"
-        source: "com.orange.camara.qod"
+        source: "https://notificationSendServer12.supertelco.com"
         type: "org.camaraproject.qod.qos-status-changed-event"
         specversion: "1.0"
         time: "2023-01-17T13:18:23.682Z"

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -67,13 +67,17 @@ tags:
     description: |
       Events received on subscription listener side.
 paths:
-  /cloudevents:
+  /your_webhook_notificationUrl:
     post:
       tags:
         - CAMARA Cloud Event notification endpoint
       summary: "Cloud Event notification endpoint to notify consumer that statement of fact had occurred"
-      description: Cloud Event notification endpoint to notify consumer that statement of fact occurred. This endpoint must be exposed on the consumer side.
-      operationId: notifyCloudEvent
+      description: |
+        INFORMATIVE ENDPOINT: The value of this endpoint is freely declared by each client app by means of resource-based
+        subscription or instance-based subscription. /your_webhook_notificationUrl is 
+        just a convention naming referring to an absolute URL, indeed the one indicated by API client
+        in the triggering of the procedure (resource-based or instance-based).
+      operationId: sendEvent
       requestBody:
         required: true
         content:

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -54,14 +54,11 @@ security:
   - oAuth2ClientCredentials: []
 
 servers:
-  - url: '{apiRoot}/{basePath}'
+  - url: '{apiRoot}'
     variables:
       apiRoot:
         default: http://localhost:8080
-        description: API root
-      basePath:
-        default: /event-notification/v0
-        description: Base path for the event notification API
+        description: Can be any notification server address sent by the client application
 tags:
   - name: Cloud Event
     description: |
@@ -180,8 +177,8 @@ components:
           $ref: '#/components/schemas/Source'
         type:
           type: string
-          description: 'type of event as defined in each CAMARA API (e.g. org.camara.api.qod.QosStatusChangedEvent)'
-          example: org.camara.api.qod.QosStatusChangedEvent
+          description: 'type of event as defined in each CAMARA API (e.g.: org.camara.qod.qos-status-changed-event)'
+          example: org.camara.qod.qos-status-changed-event
           minLength: 15
         specversion:
           type: string
@@ -283,10 +280,9 @@ components:
       value:
         id: 123e4567-e89b-12d3-a456-426655440000
         source: com.orange.camara.qod
-        type: org.camara.api.qod.QosStatusChangedEvent
+        type: org.camara.qod.qos-status-changed-event
         specversion: '1.0'
         time: 2023-01-17T13:18:23.682Z
-        subject: QOD/QOS_STATUS_CHANGED
         datacontenttype: application/json
         data:
           sessionId: 6e8bc430-9c3a-11d9-9669-0800200c9a66

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -1,0 +1,268 @@
+openapi: 3.0.3
+info:
+  title: Event Notification using CloudEvents specifications
+  description: |
+    The event notification endpoint is used by the API server to notify the API consumer that an event occurred.  The notification is the message posted on listener side.
+
+    # Introduction
+
+    A lot of CAMARA APIs offer the capability to consumer to receive event.
+    Event data are defined in each API definition but in order to provide consistency across CAMARA APIs and to increase 
+    interoperability we will use [cloudevents](https://cloudevents.io/) specifications. In particular, CAMARA Event will 
+    be defined using [cloudevents-json-format](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)
+   
+    # Relevant terms and definitions
+
+      * **Occurrence** : An "occurrence" is the capture of a statement of fact during the operation of a software system.
+  
+      * **Event**: An "event" is a data record expressing an occurrence and its context. Events are routed from an 
+    event producer (the source) to interested event consumers.
+    
+      * **Producer**: The "producer" is a specific instance, process or device that creates the data structure 
+    describing the CloudEvent.
+  
+      * **Source**:  The "source" is the context in which the occurrence happened. In a distributed system it might 
+    consist of multiple producers. If a source is not aware of CloudEvents, an external producer creates 
+    the CloudEvent on behalf of the source.
+  
+      * **Consumer**: A "consumer" receives the event and acts upon it. It uses the context and data to execute some 
+    logic, which might lead to the occurrence of new events.
+  
+      * **Data**:  Domain-specific information about the occurrence (i.e. the payload). This might 
+    include information about the occurrence, details about the data that was changed, or more.
+  
+    
+    # API Functionality   
+      
+    Only one endpoint/operation is provided: `POST /cloudevents`
+    
+    This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
+  
+  
+
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: project-email@sample.com
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.5.0-wip
+externalDocs:
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/
+security:
+  - oAuth2ClientCredentials: []
+
+servers:
+  - url: '{apiRoot}/{basePath}'
+    variables:
+      apiRoot:
+        default: http://localhost:8080
+        description: API root
+      basePath:
+        default: /event-notification/v0
+        description: Base path for the event notification API
+tags:
+  - name: Cloud Event
+    description: |
+      Events received on subscription listener side.
+paths:
+  /notifications:
+    post:
+      tags:
+        - CAMARA Cloud Event Notification
+      summary: "Notification endpoint to notify consumer that statement of fact had occurred"
+      description: Notification endpoint to notify consumer that statement of fact occurred. This endpoint must be exposed on the consumer side.
+      operationId: notifyCloudEvent
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              $ref: "#/components/schemas/CloudEvent"
+            examples:
+              QOS_STATUS_CHANGED_EXAMPLE:
+                $ref: '#/components/examples/QOS_STATUS_CHANGED_EXAMPLE'
+
+      responses:
+        201:
+          description: Created
+        202:
+          description: Accepted
+        400:
+          $ref: "#/components/responses/Generic400"
+        401:
+          $ref: "#/components/responses/Generic401"
+        403:
+          $ref: "#/components/responses/Generic403"
+        500:
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorInfo"
+        503:
+          $ref: "#/components/responses/Generic503"
+components:
+  securitySchemes:
+    oAuth2ClientCredentials:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: '{tokenUrl}'
+          scopes: {}
+
+  schemas:
+    ErrorInfo:
+      type: object
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          description: HTTP response status code
+        code:
+          type: string
+          description: Code given to this error
+        message:
+          type: string
+          description: Detailed error description
+
+    DateTime:
+      type: string
+      format: date-time
+      description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+      example: '2018-04-05T17:31:00Z'
+
+    Source:
+      type: string
+      format: uri-reference
+      minLength: 1
+      description: "Identifies the context in which an event happened(example: 'com.orange.camara.qod')"
+      example:
+        - https://github.com/cloudevents
+        - mailto:cncf-wg-serverless@lists.cncf.io
+        - urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+        - cloudevents/spec/pull/123
+        - /sensors/tn-1234567/alerts
+        - 1-555-123-4567
+
+    CloudEvent:
+      description: The notification callback
+      required:
+        - id
+        - source
+        - specversion
+        - type
+      properties:
+        id:
+          type: string
+          description: identifier of this event, that must be unique in the source context.
+        source:
+          $ref: '#/components/schemas/Source'
+        type:
+          type: string
+          description: 'type of event as defined in each CAMARA API (examples: ROAMING_STATUS, QOS_STATUS_CHANGED, PAYMENT_COMPLETED, etc...)'
+          example: ROAMING_ON
+        specversion:
+          type: string
+          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
+        datacontenttype:
+          type: string
+          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+        data:
+          type: object
+          description: Event details payload described in each CAMARA API and referenced by its type
+        subject:
+          description: Describes the subject of the event in the context of the event producer (identified by source).
+          type: string
+          example: ROAMING
+        time:
+          $ref: "#/components/schemas/DateTime"
+
+  responses:
+    Generic400:
+      description: Problem with the client request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 400
+            code: "INVALID_ARGUMENT"
+            message: "Client specified an invalid argument, request body or query param"
+    Generic401:
+      description: Authentication problem with the client request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 401
+            code: "UNAUTHENTICATED"
+            message: "Request not authenticated due to missing, invalid, or expired credentials"
+    Generic403:
+      description: Client does not have sufficient permission
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 403
+            code: "PERMISSION_DENIED"
+            message: "Client does not have sufficient permissions to perform this action"
+    Generic404:
+      description: Resource Not Found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            code: NOT_FOUND
+            message: "The specified resource is not found"
+    Generic409:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            code: CONFLICT
+            message: "The specified resource is in a conflict"
+    Generic500:
+      description: Server error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 500
+            code: "INTERNAL"
+            message: "Server error"
+    Generic503:
+      description: Service unavailable. Typically the server is down.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            status: 503
+            code: "UNAVAILABLE"
+            message: "Service unavailable"
+  examples:
+    QOS_STATUS_CHANGED_EXAMPLE:
+      value:
+        id: 123654
+        source: com.orange.camara.qod
+        type: QOS_STATUS_CHANGED
+        specversion: '1.0'
+        time: 2023-01-17T13:18:23.682Z
+        datacontenttype: application/json
+        subject: QOD
+        data:
+          sessionId: 6e8bc430-9c3a-11d9-9669-0800200c9a66
+          qosStatus: UNAVAILABLE
+          statusInfo: DURATION_EXPIRED
+

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -67,12 +67,12 @@ tags:
     description: |
       Events received on subscription listener side.
 paths:
-  /notifications:
+  /cloudevents:
     post:
       tags:
-        - CAMARA Cloud Event Notification
-      summary: "Notification endpoint to notify consumer that statement of fact had occurred"
-      description: Notification endpoint to notify consumer that statement of fact occurred. This endpoint must be exposed on the consumer side.
+        - CAMARA Cloud Event notification endpoint
+      summary: "Cloud Event notification endpoint to notify consumer that statement of fact had occurred"
+      description: Cloud Event notification endpoint to notify consumer that statement of fact occurred. This endpoint must be exposed on the consumer side.
       operationId: notifyCloudEvent
       requestBody:
         required: true
@@ -89,12 +89,26 @@ paths:
           description: Created
         202:
           description: Accepted
+        204:
+          description: No Content
+        200:
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
         400:
           $ref: "#/components/responses/Generic400"
         401:
           $ref: "#/components/responses/Generic401"
         403:
           $ref: "#/components/responses/Generic403"
+        410:
+          $ref: "#/components/responses/Generic410"
+        415:
+          $ref: "#/components/responses/Generic415"
+        429:
+          $ref: "#/components/responses/Generic429"
         500:
           description: Server error
           content:
@@ -164,8 +178,8 @@ components:
           $ref: '#/components/schemas/Source'
         type:
           type: string
-          description: 'type of event as defined in each CAMARA API (examples: ROAMING_STATUS, QOS_STATUS_CHANGED, PAYMENT_COMPLETED, etc...)'
-          example: ROAMING_ON
+          description: 'type of event as defined in each CAMARA API (e.g. org.camara.api.qod.QosStatusChangedEvent)'
+          example: org.camara.api.qod.QosStatusChangedEvent
         specversion:
           type: string
           description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
@@ -231,6 +245,33 @@ components:
           example:
             code: CONFLICT
             message: "The specified resource is in a conflict"
+    Generic410:
+      description: Gone
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            code: GONE
+            message: "Access to the target resource is no longer available."
+    Generic415:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            code: UNSUPPORTED_MEDIA_TYPE
+            message: "The specified media type is not supported"
+    Generic429:
+      description: Too Many Requests
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorInfo"
+          example:
+            code: TOO_MANY_REQUESTS
+            message: "Endpoint does not support as many requests per time slot"
     Generic500:
       description: Server error
       content:

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -151,7 +151,7 @@ components:
       format: uri-reference
       minLength: 1
       description: "Identifies the context in which an event happened - be a non-empty `URI-reference."
-     examples:
+      example:
         absolute_uri_https:
           value: https://github.com/cloudevents
         absolute_uri_mailto:

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -161,8 +161,7 @@ components:
       example: "https://notificationSendServer12.supertelco.com"
 
     CloudEvent:
-      description: |
-        The notification callback that can be extended by adding data field in child classes
+      description: The notification callback
       required:
         - id
         - source
@@ -188,6 +187,9 @@ components:
         datacontenttype:
           type: string
           description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+        data:
+          type: object
+          description: Event details payload described in each CAMARA API and referenced by its type
         time:
           $ref: "#/components/schemas/DateTime"
 

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -161,7 +161,8 @@ components:
       example: "https://notificationSendServer12.supertelco.com"
 
     CloudEvent:
-      description: The notification callback
+      description: |
+        The notification callback that can be extended by adding data field in child classes
       required:
         - id
         - source
@@ -186,9 +187,6 @@ components:
         datacontenttype:
           type: string
           description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
-        data:
-          type: object
-          description: Event details payload described in each CAMARA API and referenced by its type
         time:
           $ref: "#/components/schemas/DateTime"
 

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -150,7 +150,7 @@ components:
       type: string
       format: uri-reference
       minLength: 1
-      description: "Identifies the context in which an event happened(example: 'com.orange.camara.qod')"
+      description: "Identifies the context in which an event happened - be a non-empty `URI-reference`.
       example:
         - https://github.com/cloudevents
         - mailto:cncf-wg-serverless@lists.cncf.io

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -148,18 +148,17 @@ components:
       type: string
       format: uri-reference
       minLength: 1
-      description: "Identifies the context in which an event happened - be a non-empty `URI-reference`."
-      example:
-        absolute_uri_https:
-          value: https://github.com/cloudevents
-        absolute_uri_mailto:
-          value: mailto:cncf-wg-serverless@lists.cncf.io
-        URN_with_UUID:
-          value: urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
-        application_specific_relative_reference:
-          value: /cloudevents/spec/pull/123
-        application_specific:
-          value: 1-555-123-4567
+      description: |
+        Identifies the context in which an event happened - be a non-empty `URI-reference` like:
+        - URI with a DNS authority:
+          * https://github.com/cloudevents
+          * mailto:cncf-wg-serverless@lists.cncf.io
+        - Universally-unique URN with a UUID:
+          * urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+        - Application-specific identifier:
+          * /cloudevents/spec/pull/123
+          * 1-555-123-4567
+      example: "https://notificationSendServer12.supertelco.com"
 
     CloudEvent:
       description: The notification callback

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -176,7 +176,7 @@ components:
         type:
           type: string
           description: 'type of event as defined in each CAMARA API (e.g.: org.camaraproject.qod.qos-status-changed-event)'
-          example: org.camaraproject.qod.qos-status-changed-event
+          example: 'org.camaraproject.qod.qos-status-changed-event'
           minLength: 25
         specversion:
           type: string

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -34,7 +34,7 @@ info:
     
     # API Functionality   
       
-    Only one endpoint/operation is provided: `POST /your_webhook_notificationUrl`
+    Only one endpoint/operation is provided: `POST /your_webhook_notification_url`
     
     This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
   
@@ -67,17 +67,17 @@ tags:
     description: |
       Events received on subscription listener side.
 paths:
-  /your_webhook_notificationUrl:
+  /your_webhook_notification_url:
     post:
       tags:
         - CAMARA Cloud Event notification endpoint
       summary: "Cloud Event notification endpoint to notify consumer that statement of fact had occurred"
       description: |
         INFORMATIVE ENDPOINT: The value of this endpoint is freely declared by each client app by means of resource-based
-        subscription or instance-based subscription. /your_webhook_notificationUrl is 
+        subscription or instance-based subscription. /your_webhook_notification_url is 
         just a convention naming referring to an absolute URL, indeed the one indicated by API client
         in the triggering of the procedure (resource-based or instance-based).  In this way, it represents an absolute
-        URL, i.e.: notifications won't be sent to /event-notification/vX/your_webhook_notificationUrl.
+        URL, i.e.: notifications won't be sent to /event-notification/vX/your_webhook_notification_url.
       operationId: sendEvent
       requestBody:
         required: true
@@ -115,11 +115,7 @@ paths:
         429:
           $ref: "#/components/responses/Generic429"
         500:
-          description: Server error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorInfo"
+          $ref: "#/components/responses/Generic500"
         503:
           $ref: "#/components/responses/Generic503"
 components:
@@ -179,15 +175,18 @@ components:
         id:
           type: string
           description: identifier of this event, that must be unique in the source context.
+          minLength: 1
         source:
           $ref: '#/components/schemas/Source'
         type:
           type: string
           description: 'type of event as defined in each CAMARA API (e.g. org.camara.api.qod.QosStatusChangedEvent)'
           example: org.camara.api.qod.QosStatusChangedEvent
+          minLength: 15
         specversion:
           type: string
           description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
+          minLength: 3
         datacontenttype:
           type: string
           description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
@@ -232,24 +231,6 @@ components:
             status: 403
             code: "PERMISSION_DENIED"
             message: "Client does not have sufficient permissions to perform this action"
-    Generic404:
-      description: Resource Not Found
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          example:
-            code: NOT_FOUND
-            message: "The specified resource is not found"
-    Generic409:
-      description: Conflict
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInfo"
-          example:
-            code: CONFLICT
-            message: "The specified resource is in a conflict"
     Generic410:
       description: Gone
       content:
@@ -300,7 +281,7 @@ components:
   examples:
     QOS_STATUS_CHANGED_EXAMPLE:
       value:
-        id: 123654
+        id: 123e4567-e89b-12d3-a456-426655440000
         source: com.orange.camara.qod
         type: org.camara.api.qod.QosStatusChangedEvent
         specversion: '1.0'

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -150,7 +150,7 @@ components:
       type: string
       format: uri-reference
       minLength: 1
-      description: "Identifies the context in which an event happened - be a non-empty `URI-reference`.
+      description: "Identifies the context in which an event happened - be a non-empty `URI-reference."
       example:
         - https://github.com/cloudevents
         - mailto:cncf-wg-serverless@lists.cncf.io

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -256,11 +256,11 @@ components:
       value:
         id: 123654
         source: com.orange.camara.qod
-        type: QOS_STATUS_CHANGED
+        type: org.camara.api.qod.QosStatusChangedEvent
         specversion: '1.0'
         time: 2023-01-17T13:18:23.682Z
+        subject: QOD/QOS_STATUS_CHANGED
         datacontenttype: application/json
-        subject: QOD
         data:
           sessionId: 6e8bc430-9c3a-11d9-9669-0800200c9a66
           qosStatus: UNAVAILABLE

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -276,14 +276,14 @@ components:
   examples:
     QOS_STATUS_CHANGED_EXAMPLE:
       value:
-        id: 123e4567-e89b-12d3-a456-426655440000
-        source: com.orange.camara.qod
-        type: org.camaraproject.qod.qos-status-changed-event
-        specversion: '1.0'
-        time: 2023-01-17T13:18:23.682Z
-        datacontenttype: application/json
+        id: "123e4567-e89b-12d3-a456-426655440000"
+        source: "com.orange.camara.qod"
+        type: "org.camaraproject.qod.qos-status-changed-event"
+        specversion: "1.0"
+        time: "2023-01-17T13:18:23.682Z"
+        datacontenttype: "application/cloudevents+json"
         data:
-          sessionId: 6e8bc430-9c3a-11d9-9669-0800200c9a66
+          sessionId: "6e8bc430-9c3a-11d9-9669-0800200c9a66"
           qosStatus: UNAVAILABLE
           statusInfo: DURATION_EXPIRED
 

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -150,7 +150,7 @@ components:
       type: string
       format: uri-reference
       minLength: 1
-      description: "Identifies the context in which an event happened - be a non-empty `URI-reference."
+      description: "Identifies the context in which an event happened - be a non-empty `URI-reference`."
       example:
         absolute_uri_https:
           value: https://github.com/cloudevents

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -281,7 +281,7 @@ components:
         type: "org.camaraproject.qod.qos-status-changed-event"
         specversion: "1.0"
         time: "2023-01-17T13:18:23.682Z"
-        datacontenttype: "application/cloudevents+json"
+        datacontenttype: "application/json"
         data:
           sessionId: "6e8bc430-9c3a-11d9-9669-0800200c9a66"
           qosStatus: UNAVAILABLE

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -35,10 +35,6 @@ info:
     
     Only one endpoint/operation is provided: `POST /your_webhook_notification_url`
     This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
-  
-    # Security
-    
-    Security is the responsibility of the API provider. The API provider must include its requirements in the security section of this specification or remove this section if it does not support any authentication scheme.
 
   termsOfService: http://swagger.io/terms/
   contact:
@@ -52,6 +48,7 @@ externalDocs:
   url: https://github.com/camaraproject/
 security:
   - oAuth2ClientCredentials: []
+  - {}
 
 servers:
   - url: '{apiRoot}'
@@ -123,7 +120,6 @@ components:
         clientCredentials:
           tokenUrl: '{tokenUrl}'
           scopes: {}
-
   schemas:
     ErrorInfo:
       type: object

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -34,7 +34,7 @@ info:
     
     # API Functionality   
       
-    Only one endpoint/operation is provided: `POST /cloudevents`
+    Only one endpoint/operation is provided: `POST /your_webhook_notificationUrl`
     
     This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
   
@@ -46,7 +46,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.5.0-wip
+  version: 0.1.0-wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
@@ -76,7 +76,8 @@ paths:
         INFORMATIVE ENDPOINT: The value of this endpoint is freely declared by each client app by means of resource-based
         subscription or instance-based subscription. /your_webhook_notificationUrl is 
         just a convention naming referring to an absolute URL, indeed the one indicated by API client
-        in the triggering of the procedure (resource-based or instance-based).
+        in the triggering of the procedure (resource-based or instance-based).  In this way, it represents an absolute
+        URL, i.e.: notifications won't be sent to /event-notification/vX/your_webhook_notificationUrl.
       operationId: sendEvent
       requestBody:
         required: true


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This PR increase interoperability between our ecosystem and rest of world using a defacto standard

#### Which issue(s) this PR fixes:

Fixes #8 

#### Special notes for reviewers:
BREAKING CHANGES:

- Impacts APIs that define Event notifications (QoD, device status, ...)
- Need to update guidelines to integrate cloudevents references.

#### Changelog input

```
Integrates the cloudevents specification as the basis for CAMARA notifications
```

#### Additional documentation 