### PR TITLE
Add reserved word restrictions to API-design-guidelines.md

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -966,7 +966,7 @@ Below considerations should be checked when an API is documented:
     - [OpenAPI Generator (Java)](https://openapi-generator.tech/docs/generators/java/#reserved-words)
     - [OpenAPI Generator (Go)](https://openapi-generator.tech/docs/generators/go/#reserved-words)
     - [OpenAPI Generator (Kotlin)](https://openapi-generator.tech/docs/generators/kotlin/#reserved-words)
-    - [OpenAPI Generator (Swift)](https://openapi-generator.tech/docs/generators/swift5#reserved-words)
+    - [OpenAPI Generator (Swift5)](https://openapi-generator.tech/docs/generators/swift5#reserved-words)
 
 ### 11.1 General Information
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -953,6 +953,16 @@ Below considerations should be checked when an API is documented:
    -  Response Structure ([Section 11.4](#114-response-structure))
    -  Data Definitions ([Section 11.5](#115-data-definitions))
    -  OAuth Definition ([Section 11.6](#116-oauth-definition))
+- To avoid issues with implementation using Open API generators:
+  - Reserved words must not be used in the following parts of an API specification:
+    - Path and operation names
+    - Path or query parameter names
+    - Request and response body property names
+    - Security schemes
+    - Component names
+    - OperationIds
+  - A reserved word is one whose usage is reserved by any of the following Open API generators:
+    - [Python Flask](https://openapi-generator.tech/docs/generators/python-flask/#reserved-words)
 
 ### 11.1 General Information
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -963,6 +963,10 @@ Below considerations should be checked when an API is documented:
     - OperationIds
   - A reserved word is one whose usage is reserved by any of the following Open API generators:
     - [Python Flask](https://openapi-generator.tech/docs/generators/python-flask/#reserved-words)
+    - [OpenAPI Generator (Java)](https://openapi-generator.tech/docs/generators/java/#reserved-words)
+    - [OpenAPI Generator (Go)](https://openapi-generator.tech/docs/generators/go/#reserved-words)
+    - [OpenAPI Generator (Kotlin)](https://openapi-generator.tech/docs/generators/kotlin/#reserved-words)
+    - [OpenAPI Generator (Swift)](https://openapi-generator.tech/docs/generators/swift5#reserved-words)
 
 ### 11.1 General Information
 


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Adds restrictions on use of Open API generator reserved words in an API specification, and adds a link to the current reserved word list for Python Flask.

#### Which issue(s) this PR fixes:
<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #29

#### Special notes for reviewers:
Additional reserved word list can be added by other developers

#### Changelog input

```
 release-note
- Adds restrictions on use of Open API generator reserved words in an API specification
- Adds a link to the current reserved word list for Python Flask.
```

#### Additional documentation 
```
docs
- [Python Flask Reserved Words](https://openapi-generator.tech/docs/generators/python-flask/#reserved-words)
```