### PR TITLE
Remove option to use HTTP HEAD from API-design-guidelines.md

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -258,7 +258,6 @@ PUT |  Update | Replaces a specific resource. Returns the resource URL when the 
 DELETE | Delete | Delete a specific resource.  |
 PATCH |  Update | Updates a specific resource, applying all changes at the same time. If resource does not exist, it will be created. Returns the resource URL when the update ends. If any error occurs during the update, all of them will be cancelled.   |
 OPTIONS | Read | Returns a 200 OK with an allowed methods list in the specific resource destined to the header allowed joined to an HTML document about the resource + an API Doc link.  |
-HEAD | Read | Returns the resource actual status without message body. |
 
 In this document will be defined the principal verbs to use in the API definition.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:
HEAD requests are not suitable for network APIs managing dynamic data and there use should be prohibited. There are alternatives to HEAD requests if the purpose is to see whether the data has changed since last requested - for example, the `If-Modified-Since` header.

#### Which issue(s) this PR fixes:
<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #28

#### Special notes for reviewers:
No APIs currently define HEAD requests

#### Changelog input
```
 release-note
 - Remove option to use HTTP HEAD from API design guidelines
```

#### Additional documentation 
N/A