### PR TITLE
Set X-Correlator as Required in OAS Definition, X-Version removed

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -814,8 +814,7 @@ With the aim of standardizing the request observability and traceability process
 
 | Name | Description |  Type | Pattern	| Longitude | Location | Required by API Consumer | Required in OAS Definition |	Example | 
 |---|---|---|---|---|---|---|---|---|
-| `X-Version` |	Service version description to help observability process |	String| N/A	| | Request | No | No | |	
-| `X-Correlator`|	Service correlator to make E2E observability |		String |	UUID (8-4-4-4-12)	| Max 36	| Request/Response | No | No |	b4333c46-49c0-4f62-80d7-f0ef930f1c46 |
+| `X-Correlator`|	Service correlator to make E2E observability |		String |	UUID (8-4-4-4-12)	| Max 36	| Request/Response | No | Yes |	b4333c46-49c0-4f62-80d7-f0ef930f1c46 |
 
 When the API Consumer includes the "X-Correlator" header in the request, the API provider must include it in the response with the same UUID as was used in the request. Otherwise, it is optional to include the "X-Correlator" header in the response with any valid (preferably randomly chosen) UUID.
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:

- Removed X-Version
- X-Correlator is now set as "Required in OAS Definition"

#### Which issue(s) this PR fixes:

Fixes #101 
