### PR TITLE
[Bugfix]: Linting rules problem with Traffic Influence API #161

### DIFF
--- a/artifacts/linting_rules/.spectral.yml
+++ b/artifacts/linting_rules/.spectral.yml
@@ -1,6 +1,6 @@
 # CAMARA Project - linting ruleset - documentation avaialable here:
 # https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md
-# 31.01.2024 - initial version
+# 19.03.2024 - camara-http-method rule corrected
 
 extends: "spectral:oas"
 functions:

--- a/artifacts/linting_rules/.spectral.yml
+++ b/artifacts/linting_rules/.spectral.yml
@@ -1,6 +1,9 @@
 # CAMARA Project - linting ruleset - documentation avaialable here:
 # https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md
-# 19.03.2024 - camara-http-method rule corrected
+# Changelog:
+# - 31.01.2024: Initial version
+# - 19.03.2024: Corrected camara-http-methods rule
+
 
 extends: "spectral:oas"
 functions:

--- a/artifacts/linting_rules/.spectral.yml
+++ b/artifacts/linting_rules/.spectral.yml
@@ -108,7 +108,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^(get|put|post|delete|patch|options)$"
+        match: "^(get|put|post|delete|patch|options|parameters)$"
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-get-no-request-body:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug


#### What this PR does / why we need it:
Fixing camara-http-method rule to include parameters as valid identifier under path.



#### Which issue(s) this PR fixes:

[<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
](https://github.com/camaraproject/Commonalities/issues/161)
Fixes #161 

#### Special notes for reviewers:

Hello Team, 
As per the issue #161, this PR solves the problem of giving error on using 'parameters' under path for traffic Influence API yaml file related to camara-http-method linting rule.


#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
