### PR TITLE
update-design-doc-with-explicit-sub-scope-changes

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -966,7 +966,7 @@ Scopes should be represented as below for APIs that offer explicit event subscri
 
 For e.g. device-roaming-subscriptions:read 
   
-Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
+The format to define scopes for explicit subscriptions with action create, includes the event type in its formulation to ensure that consent is managed at the level of subscribed event types. Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
 
 - API Name: device-roaming-subscriptions
 - Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -961,7 +961,6 @@ The APIs that offer explicit event subscriptions must have a way to reflect whic
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
  
 - API Name: device-roaming-subscriptions
-- Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)
 - Grant-level, action on resource: read, delete
 This type of formulation is not needed for the create action.
 
@@ -970,7 +969,6 @@ For e.g. device-roaming-subscriptions:read
 The format to define scopes for explicit subscriptions with action create, includes the event type in its formulation to ensure that consent is managed at the level of subscribed event types. Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
 
 - API Name: device-roaming-subscriptions
-- Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)
 - Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on 
 - Grant-level, action on resource: create
 
@@ -1355,7 +1353,7 @@ Note: It is perfectly valid for a CAMARA API to have several event types managed
 
 In order to ease developer adoption, the pattern for Resource-based event subscription should be consistent for all API providing this feature.
 
-To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. It is recommended when possible to append the keyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
+To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s.  It is mandatory to append the keyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
 
 4 operations must be defined:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -979,7 +979,7 @@ To correctly define the scopes, when creating them, the following recommendation
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.
 - **Use a common nomenclature for all resources**.  Scopes must be descriptive names and that there is no conflict between the different resources.
 - **Use the kebab-case nomenclature** to define API names, resources, and scope permissions.
-- **Use** ":" as the separator between API name, protected resources, event-types and grant-levels.
+- **Using ":" a separator** between API name, protected resources, event-types and grant-levels for consistency.
 
 See section [11.6 Security Definition](#116-security-definition) for detailed guidelines on how to define scopes and other security-related properties in a OpenAPI file.
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1355,7 +1355,7 @@ Note: It is perfectly valid for a CAMARA API to have several event types managed
 
 In order to ease developer adoption, the pattern for Resource-based event subscription should be consistent for all API providing this feature.
 
-To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. It is recommended when possible to append the keyyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
+To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. It is recommended when possible to append the keyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
 
 4 operations must be defined:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -950,8 +950,8 @@ The following controls will be performed on the access token:
 The scopes allow defining the permission scopes that a system or a user has on a resource, ensuring that they can only access the parts they need and not have access to more. These restrictions are done by limiting the permissions that are granted to OAuth tokens.
 
 Scopes should be represented as below for all Camara APIs except the APIs that offer explicit event subscriptions:
-- API Name: address-management, numbering-information...
-- Protected Resource: orders, billings…
+- API Name: qod, address-management, numbering-information...
+- Protected Resource: sessions, orders, billings…
 - Grant-level, action on resource: read, write…
 
 For e.g. qod:sessions:read
@@ -961,6 +961,7 @@ The APIs that offer explicit event subscriptions must have a way to reflect whic
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
  
 - API Name: device-roaming-subscriptions
+- Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)
 - Grant-level, action on resource: read, delete
 
 For e.g. device-roaming-subscriptions:read 
@@ -968,6 +969,7 @@ For e.g. device-roaming-subscriptions:read
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
 
 - API Name: device-roaming-subscriptions
+- Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)
 - Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on 
 - Grant-level, action on resource: create
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1353,7 +1353,7 @@ Note: It is perfectly valid for a CAMARA API to have several event types managed
 
 In order to ease developer adoption, the pattern for Resource-based event subscription should be consistent for all API providing this feature.
 
-To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s.  It is mandatory to append the keyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
+To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. It is mandatory to append the keyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
 
 4 operations must be defined:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -963,6 +963,7 @@ Scopes should be represented as below for APIs that offer explicit event subscri
 - API Name: device-roaming-subscriptions
 - Protected Resource: subscriptions (If the API name offering explicit subscriptions does not include the word subscriptions, then the protected resource "subscriptions" should be added when defining the scope.)
 - Grant-level, action on resource: read, delete
+This type of formulation is not needed for the create action.
 
 For e.g. device-roaming-subscriptions:read 
   

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -979,6 +979,7 @@ To correctly define the scopes, when creating them, the following recommendation
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.
 - **Use a common nomenclature for all resources**.  Scopes must be descriptive names and that there is no conflict between the different resources.
 - **Use the kebab-case nomenclature** to define API names, resources, and scope permissions.
+- **Use** ":" as the separator between API name, protected resources, event-types and grant-levels.
 
 See section [11.6 Security Definition](#116-security-definition) for detailed guidelines on how to define scopes and other security-related properties in a OpenAPI file.
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -954,7 +954,7 @@ Scopes should be represented as below for all Camara APIs except the APIs that o
 - Protected Resource: orders, billings…
 - Grant-level, action on resource: read, write…
 
-For e.g. qod-sessions-read
+For e.g. qod:sessions:read
 
 The APIs that offer explicit event subscriptions must have a way to reflect which event types are being subscribed to, when a subscription create request is made. This will impact how consent management is handled for these APIs. 
 
@@ -963,15 +963,15 @@ Scopes should be represented as below for APIs that offer explicit event subscri
 - API Name: device-roaming-subscriptions
 - Grant-level, action on resource: read, delete
 
-For e.g. device-roaming-subscriptions-read
+For e.g. device-roaming-subscriptions:read 
   
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
 
 - API Name: device-roaming-subscriptions
-- Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on (As API name is already a part of the event type field, we do not prepend it again within the scope)
+- Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on 
 - Grant-level, action on resource: create
 
-For e.g. device-roaming-subscriptions-org.camaraproject.device-roaming-subscriptions.v0.roaming-on-create
+For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
   
 To correctly define the scopes, when creating them, the following recommendations should be taken:
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -949,10 +949,22 @@ The following controls will be performed on the access token:
 
 The scopes allow defining the permission scopes that a system or a user has on a resource, ensuring that they can only access the parts they need and not have access to more. These restrictions are done by limiting the permissions that are granted to OAuth tokens.
 
-Scopes should be represented as:
+Scopes should be represented as below for all Camara APIs except the APIs that offer explicit event subscriptions:
 - API Name: address-management, numbering-information...
 - Protected Resource: orders, billings…
 - Grant-level, action on resource: read, write…
+
+The APIs that offer a way to subscribe to events (explicit subscriptions) must have a way to reflect which event types are being subscribed to, when a subscription create request is made. This will impact how consent management is done for these APIs. 
+
+Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
+ 
+- API Name: device-roaming-subscriptions
+- Grant-level, action on resource: read, delete
+  
+Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
+
+- Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on (As API name is already a part of the event type field, we do not prepend it again within the scope)
+- Grant-level, action on resource: create
   
 To correctly define the scopes, when creating them, the following recommendations should be taken:
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.
@@ -1331,6 +1343,8 @@ A resource-based subscription is an event subscription managed as a resource. Th
 Note: It is perfectly valid for a CAMARA API to have several event types managed. The subscription endpoint will be unique, but 'eventType' attribute is used to distinguish distinct events subscribed.
 
 In order to ease developer adoption, the pattern for Resource-based event subscription should be consistent for all API providing this feature.
+
+To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. The name of this API must be appended with the keyword "subscriptions". For e.g. device-roaming-subscriptions.yaml
 
 4 operations must be defined:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -979,7 +979,7 @@ To correctly define the scopes, when creating them, the following recommendation
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.
 - **Use a common nomenclature for all resources**.  Scopes must be descriptive names and that there is no conflict between the different resources.
 - **Use the kebab-case nomenclature** to define API names, resources, and scope permissions.
-- **Using ":" a separator** between API name, protected resources, event-types and grant-levels for consistency.
+- **Use ":" a separator** between API name, protected resources, event-types and grant-levels for consistency.
 
 See section [11.6 Security Definition](#116-security-definition) for detailed guidelines on how to define scopes and other security-related properties in a OpenAPI file.
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1353,7 +1353,7 @@ Note: It is perfectly valid for a CAMARA API to have several event types managed
 
 In order to ease developer adoption, the pattern for Resource-based event subscription should be consistent for all API providing this feature.
 
-To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. The name of this API must be appended with the keyword "subscriptions". For e.g. device-roaming-subscriptions.yaml
+To ensure consistency across Camara subprojects, it is necessary that explicit subscriptions are handled within separate API/s. It is recommended when possible to append the keyyword "subscriptions" at the end of the API name. For e.g. device-roaming-subscriptions.yaml
 
 4 operations must be defined:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -954,17 +954,24 @@ Scopes should be represented as below for all Camara APIs except the APIs that o
 - Protected Resource: orders, billings…
 - Grant-level, action on resource: read, write…
 
-The APIs that offer a way to subscribe to events (explicit subscriptions) must have a way to reflect which event types are being subscribed to, when a subscription create request is made. This will impact how consent management is done for these APIs. 
+For e.g. qod-sessions-read
+
+The APIs that offer explicit event subscriptions must have a way to reflect which event types are being subscribed to, when a subscription create request is made. This will impact how consent management is handled for these APIs. 
 
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
  
 - API Name: device-roaming-subscriptions
 - Grant-level, action on resource: read, delete
+
+For e.g. device-roaming-subscriptions-read
   
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
 
+- API Name: device-roaming-subscriptions
 - Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on (As API name is already a part of the event type field, we do not prepend it again within the scope)
 - Grant-level, action on resource: create
+
+For e.g. device-roaming-subscriptions-org.camaraproject.device-roaming-subscriptions.v0.roaming-on-create
   
 To correctly define the scopes, when creating them, the following recommendations should be taken:
 - **Appropriate granularity**. Scopes should be granular enough to match the types of resources and permissions you want to grant.


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction



#### What this PR does / why we need it:
Explicit subscriptions need to be transparent about the event types that they offer.
Following changes are included:
- Suggests that explicit subscriptions should have a separate API file
- API name must include the keyword "subscriptions" at the end
- Suggest how scope should be represented when actions are create (subscription) and when they are delete and read (subscription)

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #163 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
