### PR TITLE
guideline_for_datacontenttype_cloudevent_concept_as_enum

### DIFF
--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -86,30 +86,11 @@ paths:
                 $ref: '#/components/examples/QOS_STATUS_CHANGED_EXAMPLE'
 
       responses:
-        201:
-          description: Created
-          headers:
-            X-Correlator:
-              $ref: "#/components/headers/X-Correlator"
-        202:
-          description: Accepted
-          headers:
-            X-Correlator:
-              $ref: "#/components/headers/X-Correlator"
         204:
           description: No Content
           headers:
             X-Correlator:
               $ref: "#/components/headers/X-Correlator"
-        200:
-          description: Ok
-          headers:
-            X-Correlator:
-              $ref: "#/components/headers/X-Correlator"
-          content:
-            application/json:
-              schema:
-                type: object
         400:
           $ref: "#/components/responses/Generic400"
         401:
@@ -202,6 +183,8 @@ components:
         datacontenttype:
           type: string
           description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+          enum:
+            - application/json
         data:
           type: object
           description: Event details payload described in each CAMARA API and referenced by its type
@@ -335,4 +318,3 @@ components:
           sessionId: "6e8bc430-9c3a-11d9-9669-0800200c9a66"
           qosStatus: UNAVAILABLE
           statusInfo: DURATION_EXPIRED
-


### PR DESCRIPTION
#### What type of PR is this?

* correction
* enhancement/feature

#### What this PR does / why we need it:

By means of this PR, two topics are covered:
- Set `datacontenttype` cloudevent field value as enum "application\json", consistently with API design guidelines
- Take advantage of this PR to align success response to `204` only, aligned with PR #189


#### Which issue(s) this PR fixes:

Fixes #192 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

N/A