### PR TITLE
API Design Guidelines chapter 11: 'info' object, 'servers' object and cleanup 

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1068,9 +1068,9 @@ Below considerations should be checked when an API is documented:
 ### 11.1 General Information
 
 This part must include the following information:
-- API Version in the next format: X.Y.Z.
 - API title with public name.
 - A brief description of the main functions of the API.
+- API Version in the format defined in [Chapter 5. Versioning](#5-versioning)
 - API Terms of Service.
 - Contact information, with name, email and website of the API Holder.
 - Licence information (name, website…)

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1096,6 +1096,7 @@ info:
   termsOfService: http://example.com/terms/
   # Contact information: name, email, URL
   contact:
+  # Link to the provider's support page.
     name: API Support
     email: support@example.com
     url: http://www.example.com/support

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1074,9 +1074,7 @@ This part must include the following information:
 - API Terms of Service.
 - Contact information, with name, email and website of the API Holder.
 - Licence information (name, website…)
-- Schemes supported (HTTP, HTTPS…)
-- Allowed response formats (“application/json”, “text/xml”…)
-- Response format (“application/jwt”…)
+- API server and base URL
 - Global `tags` object if tags are used for API operations
   
 The `info` object shall have the following content:
@@ -1107,6 +1105,18 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 ```
 
+The `servers` object shall have the following content:
+
+```yaml
+servers:
+  # apiRoot variable and the fixed base path containing <api-name> and <api-version> as defined in chapter 5  
+  - url: "{apiRoot}/quality-on-demand/vwip"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+```
+
 ### 11.2 Published Routes
 
 This part must contain the list of published functions, with the following description:
@@ -1117,6 +1127,7 @@ This part must contain the list of published functions, with the following descr
    - Optionally `tags` object for each API operation - Title Case is the recommended style for tag names.
    - Request param list, making reference to "Request params" part.
    - Supported responses list, describing success and errors cases.
+   - Allowed content type (“application/json”, “text/xml”…)
 
 <p align="center">
 <img src="./images/guidelines-fig-15.png" width="400"/>
@@ -1141,6 +1152,7 @@ This part describes the list of possible messages returned by the API. It also i
 - Name of the response object, used to refer to it in other sections.
 - Response object description.
 - Object type (basic types like string, integer... or even more complex objects defined in the "Data definition" part...)
+- Allowed content type (“application/json”, “text/xml”…)
 - Metadata links (HATEOAS)
 
 <p align="center">

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1129,22 +1129,15 @@ This part must contain the list of published functions, with the following descr
    - Supported responses list, describing success and errors cases.
    - Allowed content type (“application/json”, “text/xml”…)
 
-<p align="center">
-<img src="./images/guidelines-fig-15.png" width="400"/>
-</p>
-
 ### 11.3 Request Parameters
 
 This part contains a list of expected payload requests, if any. This description should have the following items:
 - Parameter name, used to reference it in other sections
 - Parameter description
 - Parameter place (header, route…)
-- Type (basic types like chains, integers, complex objects,...)
+- Type (basic types like strings, integers, complex objects,...)
 - Required field or optional flag
 
-<p align="center">
-<img src="./images/guidelines-fig-16.png" width="400"/>
-</p>
 
 ### 11.4 Response Structure
 
@@ -1155,9 +1148,6 @@ This part describes the list of possible messages returned by the API. It also i
 - Allowed content type (“application/json”, “text/xml”…)
 - Metadata links (HATEOAS)
 
-<p align="center">
-<img src="./images/guidelines-fig-17.png" width="400"/>
-</p>
 
 
 ### 11.5 Data Definitions
@@ -1176,21 +1166,9 @@ This part captures a detailed description of all the data structures used in the
       - Integer ones: Format (int32, int64…), min value.
 
 
-In this part, the error response structure must also be defined, which must be as follows:
-- Type (Array, Integer, Object …)
-- Mandatory fields of the structure
-- Properties:
-   - Error Code
-      - Type (Array, Integer…)
-      - Error codes supported, as Enum list
-   - Error description
-       - Type (Array)
-       - Min longitude
-       - Max longitude
+In this part, the error response structure must also be defined following the guidelines in [Chapter 6. Error Responses](#6-error-responses).
 
-<p align="center">
-<img src="./images/guidelines-fig-18.png" width="400"/>
-</p>
+
 
 #### 11.5.1 Usage of discriminator
 As mentioned in OpenAPI doc [here](https://spec.openapis.org/oas/v3.0.3#discriminator-object) usage of discriminator may

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1071,12 +1071,13 @@ This part must include the following information:
 - API title with public name.
 - A brief description of the main functions of the API.
 - API Version in the format defined in [Chapter 5. Versioning](#5-versioning)
-- API Terms of Service.
-- Contact information, with name, email and website of the API Holder.
 - Licence information (name, website…)
 - API server and base URL
 - Global `tags` object if tags are used for API operations
-  
+
+#### Info object
+
+ 
 The `info` object shall have the following content:
 
 ```yaml
@@ -1092,19 +1093,20 @@ info:
     CAMARA guidelines defines a set of authorization flows ...
   # API version - Aligned to SemVer 2.0 according to CAMARA versioning guidelines
   version: 1.0.1
-  # Link to the page that describes the terms of service - to be replaced by the provider's terms
-  termsOfService: http://example.com/terms/
-  # Contact information: name, email, URL
-  contact:
-    name: API Support
-    email: support@example.com
-  # Link to the provider's support page.
-    url: http://www.example.com/support
   # Name of the license and a URL to the license description
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+  # CAMARA Commonalities version - x.y.z
+  x-camara-commonalities: 0.4.0
 ```
+
+The `termsOfService` and `contact` fields are optional in OpenAPI specification and may be added by API Providers documenting their APIs.
+
+The extension field `x-camara-commonalities` indicates version of CAMARA Commonalities guidelines that given API specification adheres to.
+
+
+#### Servers object
 
 The `servers` object shall have the following content:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1111,7 +1111,7 @@ The `servers` object shall have the following content:
 ```yaml
 servers:
   # apiRoot variable and the fixed base path containing <api-name> and <api-version> as defined in chapter 5  
-  - url: "{apiRoot}/quality-on-demand/vwip"
+  - url: {apiRoot}/quality-on-demand/v2
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1092,13 +1092,13 @@ info:
     CAMARA guidelines defines a set of authorization flows ...
   # API version - Aligned to SemVer 2.0 according to CAMARA versioning guidelines
   version: 1.0.1
-  # Link to the page that describes the terms of service - to be replaced by the provider' terms'
+  # Link to the page that describes the terms of service - to be replaced by the provider's terms
   termsOfService: http://example.com/terms/
   # Contact information: name, email, URL
   contact:
-  # Link to the provider's support page.
     name: API Support
     email: support@example.com
+  # Link to the provider's support page.
     url: http://www.example.com/support
   # Name of the license and a URL to the license description
   license:

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1079,9 +1079,33 @@ This part must include the following information:
 - Response format (“application/jwt”…)
 - Global `tags` object if tags are used for API operations
   
-<p align="center">
-<img src="./images/guidelines-fig-14.png" width="400"/>
-</p>
+The `info` object shall have the following content:
+
+```yaml
+info:
+  # title without "API" in it, e.g. "Number Verification"
+  title: Number Verification
+  # description explaining the API, part of the API documentation 
+  # text explaining how to fill the "Authorization and authentication" - see section 11.6
+  description: |
+    This API allows to verify that the provided mobile phone number is the one used in the device. It
+    verifies that the user is using a device with the same mobile phone number as it is declared.
+    ### Authorization and authentication
+    CAMARA guidelines defines a set of authorization flows ...
+  # API version - Aligned to SemVer 2.0 according to CAMARA versioning guidelines
+  version: 1.0.1
+  # Link to the page that describes the terms of service - to be replaced by the provider' terms'
+  termsOfService: http://example.com/terms/
+  # Contact information: name, email, URL
+  contact:
+    name: API Support
+    email: support@example.com
+    url: http://www.example.com/support
+  # Name of the license and a URL to the license description
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+```
 
 ### 11.2 Published Routes
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:

The definitions of 'info' and 'servers` object were added to chapter 11.
Other edits on API definition guidelines.
I propose to remove the figures as they do not add value to the text.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #199 
Fixes #201 

#### Special notes for reviewers:

Info object described in the same manner as here: https://swagger.io/docs/specification/api-general-info/


#### Changelog input

```
The definitions of 'info' and 'servers` object were added to chapter 11

```

#### Additional documentation 

