### PR TITLE
Deprecate API-Readiness-Checklist.md

### DIFF
--- a/documentation/API-Readiness-Checklist.md
+++ b/documentation/API-Readiness-Checklist.md
@@ -1,2 +1,2 @@
 # API Readiness minimum criteria checklist
-**PLEASE NOTE: This document is DEPRECATED as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) was developed within Release Management Working Group.**
+**PLEASE NOTE: This document is DEPRECATED as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) is now maintained within the Release Management Working Group.**

--- a/documentation/API-Readiness-Checklist.md
+++ b/documentation/API-Readiness-Checklist.md
@@ -1,5 +1,5 @@
 # API Readiness minimum criteria checklist
-**PLEASE NOTE: This document is deprecated as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) was developed within Release Management Working Group.**
+**PLEASE NOTE: This document is DEPRECATED as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) was developed within Release Management Working Group.**
 
 ~~| No | Deliverables/Criteria      | Mandatory | Reference template                          |
 |----|--------------     |-----------|--------------------                         |

--- a/documentation/API-Readiness-Checklist.md
+++ b/documentation/API-Readiness-Checklist.md
@@ -1,13 +1,2 @@
 # API Readiness minimum criteria checklist
 **PLEASE NOTE: This document is DEPRECATED as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) was developed within Release Management Working Group.**
-
-~~| No | Deliverables/Criteria      | Mandatory | Reference template                          |
-|----|--------------     |-----------|--------------------                         |
-|  1 |API Spec          | Y         | OAS3  (https://spec.openapis.org/oas/v3.0.3)|
-|  2 |API Implementation |   N        |                                             |
-| 3   |API Documentation  |   Y        |The API specification should include all the needed documentation.                                           |
-|4   |User Stories  |   Y        |	https://github.com/camaraproject/Commonalities/blob/main/documentation/Userstory-template.md                                            |
-| 5   |API test cases and documentation  |   Y        | A Gherkin feature file will be added to the main subproject repo and this will fulfil the minimum criteria of readiness w.r.t API test cases and documentation. If subprojects also intend to add test implementations, an aligned single implementation that is agreed amongst all provider implementors could be added to the main subproject repo. If no alignment is possible, each provider implementor will add the test implementation to their own repos   |
-| 6   |Tested by at least 2 operators  |   Y        |                                             |
-| 7   |Security review  |   Y        |  Spec contributions should include a security scheme section that complies with the AuthN&AuthZ techniques agreed in Commonalities.                                   |~~
-

--- a/documentation/API-Readiness-Checklist.md
+++ b/documentation/API-Readiness-Checklist.md
@@ -1,5 +1,7 @@
 # API Readiness minimum criteria checklist
-| No | Deliverables/Criteria      | Mandatory | Reference template                          |
+**PLEASE NOTE: This document is deprecated as the updated [API Readiness Checklist](https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/API-Readiness-Checklist.md) was developed within Release Management Working Group.**
+
+~~| No | Deliverables/Criteria      | Mandatory | Reference template                          |
 |----|--------------     |-----------|--------------------                         |
 |  1 |API Spec          | Y         | OAS3  (https://spec.openapis.org/oas/v3.0.3)|
 |  2 |API Implementation |   N        |                                             |
@@ -7,5 +9,5 @@
 |4   |User Stories  |   Y        |	https://github.com/camaraproject/Commonalities/blob/main/documentation/Userstory-template.md                                            |
 | 5   |API test cases and documentation  |   Y        | A Gherkin feature file will be added to the main subproject repo and this will fulfil the minimum criteria of readiness w.r.t API test cases and documentation. If subprojects also intend to add test implementations, an aligned single implementation that is agreed amongst all provider implementors could be added to the main subproject repo. If no alignment is possible, each provider implementor will add the test implementation to their own repos   |
 | 6   |Tested by at least 2 operators  |   Y        |                                             |
-| 7   |Security review  |   Y        |  Spec contributions should include a security scheme section that complies with the AuthN&AuthZ techniques agreed in Commonalities.                                   |
+| 7   |Security review  |   Y        |  Spec contributions should include a security scheme section that complies with the AuthN&AuthZ techniques agreed in Commonalities.                                   |~~
 


### PR DESCRIPTION
#### What type of PR is this?
* documentation


#### What this PR does / why we need it:
The API-Readiness-Checklist.md is replaced by the new updated version which is located in the Release Management project.
It should be approved after merging https://github.com/camaraproject/ReleaseManagement/pull/29 .


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #202 

#### Special notes for reviewers:
I am not aware of references to the current API Readiness Checklist from other Commonalities documents.
Using Markdown ~~strikeout~~ formatting breaks table rendering, it may be clearer to keep the original table without strikeout.


#### Changelog input

```
The API-Readiness-Checklist.md is marked as deprecated

```

#### Additional documentation 

