### PR TITLE
Update API-design-guidelines.md-with-wildcard-scopes-icm-agreement

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1310,7 +1310,7 @@ where
 <br>
 
 
-##### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:
+#### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:
 
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1326,7 +1326,7 @@ Grant-level, action on resource: create
 For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
 
 #### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
-The decision on the API-level scopes was made within the [ICM working group](https://github.com/camaraproject/IdentityAndConsentManagement) and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
+The decision on the API-level scopes was made within the [Identity and Consent Management Working Group](https://github.com/camaraproject/IdentityAndConsentManagement) and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 
 ## 12. Subscription, Notification & Event

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1325,7 +1325,7 @@ Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on
 Grant-level, action on resource: create
 For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
 
-##### API-level scopes (sometimes referred to as wildcard scopes in Camara)
+##### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
 The decision on the API-level scopes was made within the ICM working group and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1310,7 +1310,7 @@ where
 <br>
 
 
-##### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this described below:
+##### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:
 
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1326,7 +1326,7 @@ Grant-level, action on resource: create
 For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
 
 ##### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
-The decision on the API-level scopes was made within the ICM working group and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
+The decision on the API-level scopes was made within the [ICM working group](https://github.com/camaraproject/IdentityAndConsentManagement) and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 
 ## 12. Subscription, Notification & Event

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1297,7 +1297,7 @@ where
     - `update`: For operations modifying the resource, typically `PUT` or `PATCH`.
     - `delete`: For operations removing the resource, typically `DELETE`.
     - `write` : For operations creating or modifying the resource, when differentiation between `create` and `update` is not needed.
-    - 
+     
 * Eventually we may need to add an additional level to the scope, such as `api-name:[resource:]action[:detail]`, to deal with cases when only a set of parameters/information has to be allowed to be returned. Guidelines should be enhanced when those cases happen.
 ###### Examples
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1276,7 +1276,7 @@ The [CAMARA API Specification - Authorization and authentication common guidelin
 
 #### 11.6.1 Scope naming
 
-Regarding scope naming, the guidelines are:
+#### Regarding scope naming for APIs which do not deal with explicit subscriptions, the guidelines are:
 
 * Define a scope per API operation with the structure:
 
@@ -1297,16 +1297,36 @@ where
     - `update`: For operations modifying the resource, typically `PUT` or `PATCH`.
     - `delete`: For operations removing the resource, typically `DELETE`.
     - `write` : For operations creating or modifying the resource, when differentiation between `create` and `update` is not needed.
-
+    - 
 * Eventually we may need to add an additional level to the scope, such as `api-name:[resource:]action[:detail]`, to deal with cases when only a set of parameters/information has to be allowed to be returned. Guidelines should be enhanced when those cases happen.
-
-##### Examples
+###### Examples
 
 | API | path | method | scope |
 | --- | --- | --- | --- |
 | location-verification | /verify | POST | `location-verification:verify` |
 | qod | /sessions | POST | `qod:sessions:create`, or<br>`qod:sessions:write` |
 | qod | /qos-profiles | GET | `qod:qos-profiles:read` |
+
+<br>
+
+
+##### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this described below:
+
+Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
+
+API Name: device-roaming-subscriptions
+Grant-level, action on resource: read, delete This type of formulation is not needed for the create action.
+For e.g. device-roaming-subscriptions:read
+
+The format to define scopes for explicit subscriptions with action create, includes the event type in its formulation to ensure that consent is managed at the level of subscribed event types. Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
+
+API Name: device-roaming-subscriptions
+Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on
+Grant-level, action on resource: create
+For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
+
+##### API-level scopes (sometimes referred to as wildcard scopes in Camara)
+The decision on the API-level scopes was made within the ICM working group and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 
 ## 12. Subscription, Notification & Event

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1325,7 +1325,7 @@ Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on
 Grant-level, action on resource: create
 For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
 
-##### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
+#### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
 The decision on the API-level scopes was made within the [ICM working group](https://github.com/camaraproject/IdentityAndConsentManagement) and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation



#### What this PR does / why we need it:
This PR includes the following changes:

- Documents the agreement in ICM on wildcard scopes discussed under the issue -(https://github.com/camaraproject/IdentityAndConsentManagement/issues/95) into the design guidelines to ensure completeness of the doc,

- The explicit subscriptions related scope changes were documented in the PR https://github.com/camaraproject/Commonalities/pull/177 .  The scope naming is described in 2 sections in the design doc - 10.2 and 11.6.1. The earlier PR only updated section 10.2 (b). This PR adds the needed content also in section 11.6.1


#### Which issue(s) this PR fixes:

Fixes #184 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
