### PR TITLE
Update content-type to `application/cloudevents+json` for CloudEvents

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -63,7 +63,7 @@ paths:
               requestBody:
                 required: true
                 content:
-                  application/json:
+                  application/cloudevents+json:
                     schema:
                       $ref: "#/components/schemas/CloudEvent"
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:
Setting the content-type of CloudEvents to `application/cloudevents+json`



#### Which issue(s) this PR fixes:

Fixes #224 

