### PR TITLE
rename_status_subscription_cloud_event

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -515,14 +515,14 @@ components:
             Current status of the subscription - Management of Subscription State engine is not mandatory for now. Note not all statuses may be considered to be implemented. Details:
               - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but subscription creation process is not finished yet.
               - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
-              - `DEACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
+              - `INACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
               - `EXPIRED`: Subscription is ended (no longer active). This status applies when subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED` event.
               - `DELETED`: Subscription is ended as deleted (no longer active). This status applies when subscription information is kept (i.e. subscription workflow is no longer active but its metainformation is kept).
           enum:
             - ACTIVATION_REQUESTED
             - ACTIVE
             - EXPIRED
-            - DEACTIVE
+            - INACTIVE
             - DELETED
       discriminator:
         propertyName: protocol


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:

Rename status `DEACTIVE` by `INACTIVE` as deactive is not an English term.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.

N/A

#### Special notes for reviewers:



#### Changelog input

```
 release-note fix in cloudevents susbcription status name

```

#### Additional documentation 

This section can be blank.



```
docs

```
