### PR TITLE
[Github-templates]: update reference to the API-design-guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/camaraproject/Commonalities/discussions
     about: Please ask and answer questions here.
   - name: 📖 CAMARA API Design Guidelines
-    url: https://github.com/camaraproject/Commonalities/documentation/API-design-guidelines.md
+    url: https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md
     about: Please refer to the design guidelines.


### PR DESCRIPTION
#### What type of PR is this?
* bug

#### What this PR does / why we need it:
Adds a valid url to the API design guidelines.



#### Which issue(s) this PR fixes:

Fixes #230 
