### PR TITLE
Proposal to simplify device object and improve interoperability

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -60,7 +60,7 @@ components:
         * `phoneNumber`
         * `networkAccessIdentifier`
         NOTE1: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
-        NOTE2: for the Commonalities meta-release v0.4, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the meta-release work is done and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
+        NOTE2: for the Commonalities release v0.4, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
    type: object
    properties:
     phoneNumber:

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -59,7 +59,8 @@ components:
         * `ipv6Address`
         * `phoneNumber`
         * `networkAccessIdentifier`
-        NOTE: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
+        NOTE1: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
+        NOTE2: for the Commonalities meta-release v0.4, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the meta-release work is done and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
    type: object
    properties:
     phoneNumber:

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -59,14 +59,11 @@ components:
         * `ipv4Address`
         * `ipv6Address`
         * `phoneNumber`
-        * `networkAccessIdentifier`
         NOTE: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
    type: object
    properties:
     phoneNumber:
      $ref: "#/components/schemas/PhoneNumber"
-    networkAccessIdentifier:
-     $ref: "#/components/schemas/NetworkAccessIdentifier"
     ipv4Address:
      $ref: "#/components/schemas/DeviceIpv4Addr"
     ipv6Address:
@@ -78,11 +75,6 @@ components:
    type: string
    pattern: '^\+[1-9][0-9]{4,14}$'
    example: "+123456789"
-
-  NetworkAccessIdentifier:
-   description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
-   type: string
-   example: "123456789@domain.com"
 
   DeviceIpv4Addr:
    type: object

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -58,11 +58,14 @@ components:
         * `ipv4Address`
         * `ipv6Address`
         * `phoneNumber`
+        * `networkAccessIdentifier`
         NOTE: the MNO might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different MNOs. In this case the identifiers MUST belong to the same device.
    type: object
    properties:
     phoneNumber:
      $ref: "#/components/schemas/PhoneNumber"
+    networkAccessIdentifier:
+     $ref: "#/components/schemas/NetworkAccessIdentifier"
     ipv4Address:
      $ref: "#/components/schemas/DeviceIpv4Addr"
     ipv6Address:
@@ -74,6 +77,11 @@ components:
    type: string
    pattern: '^\+[1-9][0-9]{4,14}$'
    example: "+123456789"
+
+  NetworkAccessIdentifier:
+   description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
+   type: string
+   example: "123456789@domain.com"
 
   DeviceIpv4Addr:
    type: object

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1822,7 +1822,7 @@ response:
 
 The documentation template below must be used as part of the API documentation in `info.description` property in the CAMARA API specs which use the `device`object defined in [CAMARA_common.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml) artifact. This template provides guidance on how to handle device information in API requests **when using 3-legged access tokens and the device can be uniquely identified by the token**.
 
-Note: With the current 3-legged authorization flows, only a single end user can be associated with the access token. For the OIDC authorization code flow, only a single device can call the `/authorize` endpoint and obtain the code. And for CIBA, `login_hint` is currently limited to a single phone number or IP address (that can optionally include a port).
+Note: With the current 3-legged authorization flows used by CAMARA, only a single end user can be associated with the access token. For the OIDC authorization code flow, only a single device can call the `/authorize` endpoint and obtain the code. And for CIBA, `login_hint` is currently limited to a single phone number or IP address (which can optionally include a port).
 
 ```md
 # Identifying a user device from the access token

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1820,14 +1820,14 @@ response:
 
 ## Appendix A: `info.description` template for `device` identification from access token
 
-The documentation template below must be used as part of the API documentation in `info.description` property in the CAMARA API specs which use the `device`object defined in [CAMARA_common.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml) artifact. This template provides guidance on how to handle device information in API requests **when using 3-legged access tokens and the device can be uniquely identified by the token**.
+The documentation template below is recommended to be used as part of the API documentation in `info.description` property in the CAMARA API specs which use the `device`object defined in [CAMARA_common.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml) artifact. This template provides guidance on how to handle device information in API requests **when using 3-legged access tokens and the device can be uniquely identified by the token**.
 
 Note: With the current 3-legged authorization flows used by CAMARA, only a single end user can be associated with the access token. For the OIDC authorization code flow, only a single device can call the `/authorize` endpoint and obtain the code. And for CIBA, `login_hint` is currently limited to a single phone number or IP address (which can optionally include a port).
 
 ```md
-# Identifying a user device from the access token
+# Identifying a device from the access token
 
-This specification defines the `device` object field as optional in API requests, specifically in cases where the API is accessed using a 3-legged access token and the device can be uniquelly identified by the token. This approach simplifies API usage for API consumers by relying on the device information associated with the access token used to invoke the API. This mechanism reduces the need for multiple identifiers and extensive validation.
+This specification defines the `device` object field as optional in API requests, specifically in cases where the API is accessed using a 3-legged access token and the device can be uniquelly identified by the token. This approach simplifies API usage for API consumers by relying on the device information associated with the access token used to invoke the API.
 
 ## Handling of device information:
 
@@ -1848,10 +1848,10 @@ This specification defines the `device` object field as optional in API requests
 ### Restrictions for tokens without an associated authenticated identifier:
 
 - For scenarios which do not have a single device identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
-
-By following these guidelines, API consumers can use the authenticated device identifier associated with 3-legged access tokens, simplifying implementation and validation. This mechanism ensures that device identification is handled efficiently and securely, and appropriately accommodates different token types.
 ```
 
-Depending on the functionality provided by the CAMARA API, some API subprojects may still define other specific identifiers that differs from the common `device` object definition. Not all APIs necessarily have to refer to a user device, e.g. Carrier Billing API only defines a phone number as a way to identify the mobile account to be billed, Know Your Costumer only defines a phone number as a way to identify the associated account data or Home Devices QoD API defines public IP v4 address as a way to identify the user home network. 
+By following these guidelines, API consumers can use the authenticated device identifier associated with 3-legged access tokens, simplifying implementation and validation. This mechanism ensures that device identification is handled efficiently and securely, and appropriately accommodates different token types.
+
+Depending on the functionality provided by the CAMARA API, some API subprojects may still define other specific identifiers that differs from the common `device` object definition. Not all APIs necessarily have to refer to a device, e.g. Carrier Billing API only defines a phone number as a way to identify the mobile account to be billed, Know Your Costumer only defines a phone number as a way to identify the associated account data or Home Devices QoD API defines public IP v4 address as a way to identify the user home network. 
 
 Therefore, the mechanism described in this template is not applicable to all APIs, but could be used as way to make `device` object more interoperable and usable for API consumers.

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -50,10 +50,10 @@ This document captures guidelines for the API design in CAMARA project. These gu
         - [Polymorphism](#polymorphism)
     - [11.6 Security definition](#116-security-definition)
       - [11.6.1 Scope naming](#1161-scope-naming)
-      - [Regarding scope naming for APIs which do not deal with explicit subscriptions, the guidelines are:](#regarding-scope-naming-for-apis-which-do-not-deal-with-explicit-subscriptions-the-guidelines-are)
+        - [APIs which do not deal with explicit subscriptions](#apis-which-do-not-deal-with-explicit-subscriptions)
           - [Examples](#examples)
-      - [Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:](#regarding-scope-naming-for-apis-which-deal-with-explicit-subscriptions-the-guidelines-propose-some-changes-as-compared-to-the-above-format-and-this-is-described-below)
-      - [API-level scopes (sometimes referred to as wildcard scopes in CAMARA)](#api-level-scopes-sometimes-referred-to-as-wildcard-scopes-in-camara)
+        - [APIs which deal with explicit subscriptions](#apis-which-deal-with-explicit-subscriptions)
+        - [API-level scopes (sometimes referred to as wildcard scopes in CAMARA)](#api-level-scopes-sometimes-referred-to-as-wildcard-scopes-in-camara)
   - [12. Subscription, Notification \& Event](#12-subscription-notification--event)
     - [12.1 Subscription](#121-subscription)
       - [Instance-based (implicit) subscription](#instance-based-implicit-subscription)
@@ -1280,7 +1280,9 @@ The [CAMARA API Specification - Authorization and authentication common guidelin
 
 #### 11.6.1 Scope naming
 
-#### Regarding scope naming for APIs which do not deal with explicit subscriptions, the guidelines are:
+##### APIs which do not deal with explicit subscriptions
+
+Regarding scope naming for APIs which do not deal with explicit subscriptions, the guidelines are:
 
 * Define a scope per API operation with the structure:
 
@@ -1303,6 +1305,7 @@ where
     - `write` : For operations creating or modifying the resource, when differentiation between `create` and `update` is not needed.
      
 * Eventually we may need to add an additional level to the scope, such as `api-name:[resource:]action[:detail]`, to deal with cases when only a set of parameters/information has to be allowed to be returned. Guidelines should be enhanced when those cases happen.
+
 ###### Examples
 
 | API | path | method | scope |
@@ -1313,8 +1316,9 @@ where
 
 <br>
 
+##### APIs which deal with explicit subscriptions
 
-#### Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:
+Regarding scope naming for APIs which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format and this is described below:
 
 Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
 
@@ -1329,7 +1333,8 @@ Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on
 Grant-level, action on resource: create
 For e.g. device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
 
-#### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
+##### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
+
 The decision on the API-level scopes was made within the [Identity and Consent Management Working Group](https://github.com/camaraproject/IdentityAndConsentManagement) and is documented in the design guidelines to ensure completeness of this document. The scopes will always be those defined in the API Specs YAML files. Thus, a scope would only provide access to all endpoints and resources of an API if it is explicitly defined in the API Spec YAML file and agreed in the corresponding API subproject. 
 
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1742,7 +1742,7 @@ This specification defines the `device` object field as optional in API requests
 
 ### Restrictions for tokens without an associated authenticated identifier:
 
-- For tokens that do not have an associated authenticated identifier, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
+- For scenarios which do not have a single device identifier associated to the token during the authentication flow, e.g. 2-legged access tokens, the `device` object MUST be provided in the API request. This ensures that the device identification is explicit and valid for each API call made with these tokens.
 
 By following these guidelines, API consumers can use the authenticated device identifier associated with 3-legged access tokens, simplifying implementation and validation. This mechanism ensures that device identification is handled efficiently and securely, and appropriately accommodates different token types.
 ```

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -30,8 +30,11 @@ This document captures guidelines for the API design in CAMARA project. These gu
     - [5.1 Versioning Strategy](#51-versioning-strategy)
     - [5.2 Backwards and Forward Compatibility](#52-backwards-and-forward-compatibility)
   - [6. Error Responses](#6-error-responses)
-    - [### 6.1 Standardized use of CAMARA error responses](#61-standardized-use-of-camara-error-responses)
-    - [### 6.2 Error Responses - Device Object](#62-error-responses---device-object)
+    - [6.1 Standardized use of CAMARA error responses](#61-standardized-use-of-camara-error-responses)
+    - [6.2 Error Responses - Device Object](#62-error-responses---device-object)
+      - [Templates](#templates)
+        - [Response template](#response-template)
+        - [Examples template](#examples-template)
   - [7. Common Data Types](#7-common-data-types)
   - [8. Pagination, Sorting and Filtering](#8-pagination-sorting-and-filtering)
     - [8.1 Pagination](#81-pagination)
@@ -43,6 +46,8 @@ This document captures guidelines for the API design in CAMARA project. These gu
     - [10.2 Security Implementation](#102-security-implementation)
   - [11. Definition in OpenAPI](#11-definition-in-openapi)
     - [11.1 General Information](#111-general-information)
+      - [Info object](#info-object)
+      - [Servers object](#servers-object)
     - [11.2 Published Routes](#112-published-routes)
     - [11.3 Request Parameters](#113-request-parameters)
     - [11.4 Response Structure](#114-response-structure)
@@ -51,6 +56,9 @@ This document captures guidelines for the API design in CAMARA project. These gu
         - [Inheritance](#inheritance)
         - [Polymorphism](#polymorphism)
     - [11.6 Security definition](#116-security-definition)
+      - [OpenAPI security schemes definition](#openapi-security-schemes-definition)
+      - [Expressing Security Requirements](#expressing-security-requirements)
+      - [Mandatory template for `info.description` in CAMARA API specs](#mandatory-template-for-infodescription-in-camara-api-specs)
       - [11.6.1 Scope naming](#1161-scope-naming)
         - [APIs which do not deal with explicit subscriptions](#apis-which-do-not-deal-with-explicit-subscriptions)
           - [Examples](#examples)
@@ -1814,6 +1822,7 @@ response:
 
 The documentation template below must be used as part of the API documentation in `info.description` property in the CAMARA API specs which use the `device`object defined in [CAMARA_common.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml) artifact. This template provides guidance on how to handle device information in API requests **when using 3-legged access tokens and the device can be uniquely identified by the token**.
 
+Note: With the current 3-legged authorization flows, only a single end user can be associated with the access token. For the OIDC authorization code flow, only a single device can call the `/authorize` endpoint and obtain the code. And for CIBA, `login_hint` is currently limited to a single phone number or IP address (that can optionally include a port).
 
 ```md
 # Identifying a user device from the access token


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* documentation

#### What this PR does / why we need it:

PR incorporating the existing DRAFT proposal to simplify the device object and improve interoperability as per issue #171. 

>The solution proposed to be covered in the scope of this meta release was:
>
>1. Apply the mechanism to rely on the access_token (not providing the device object in the API request) for 3-legged access scenarios. This would fix interoperability in all these scenarios, which is a huge improvement. We can define the device identifier as optional in the API specification and, if not provided, simply refer to access_token. The developer would simply not provide any further device information, which is simpler. The operator does not need to check that the device identifier actually matches the access_token provided and could simply rely on the access_token itself.
>2. Validate the current situation among operators regarding the support and use of the networkAccessIdentifier in order to agree on the removal of this identifier for this meta-release.
>At least these two points would be a big improvement over the current situation. To cover all 3-legged scenarios, and in other cases where it is necessary to explicitly provide the device object in the request (such as 2-legged access with client credentials), we would have a smaller set of identifiers that would mitigate the problem a bit. So far, the APIs we are discussing (Device Location family, Device Status, Quality On demand) are mostly consumed with 3-legged access_tokens.

Reference: https://github.com/camaraproject/Commonalities/issues/171#issuecomment-2129218755

#### Which issue(s) this PR fixes:

Fixes #171

#### Special notes for reviewers:

**DISCLAIMER: The proposal is a minimum proposal that does not aim to solve all existing problems, and it is recognised that it does not cover all possible future use cases. However, in the context of the next meta-release, the two proposed measures could already be of great benefit.**

- Please find relevant context in #171
- **As agreed at the 10 June WG meeting, the DRAFT proposal has been included as an appendix to the API Design Guidelines for the time being. But we would need to decide what is the best place to document it. It could be as an appendix, in another specific document in the Commonalities, or even document it in ICM if the mechanism for relying on the access token is considered more appropriate for the ICM (e.g. in "CAMARA APIs access and user consent management" doc).**

#### Changelog input

```
- Device object simplification
- Mechanism to rely on access token to obtain device information
```

#### Additional documentation 

[2024-05-23 - Commonalities Ad-Hoc Meeting - Device Object review](https://wiki.camaraproject.org/display/CAM/2024-05-23+-+Commonalities+Ad-Hoc+Meeting+-+Device+Object+review)
