### PR TITLE
Add `minItems: 1` & `maxItems: 1` for subscription `types`

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -308,6 +308,7 @@ components:
             Note: for the Commonalities meta-release v0.4 we enforce to have only event type per subscription then for following meta-release use of array MUST be decided
              at API project level.
           type: array
+          minItems: 1
           items:
             type: string
         config:
@@ -487,6 +488,7 @@ components:
             Note: for the Commonalities meta-release v0.4 we enforce to have only event type per subscription then for following meta-release use of array MUST be decided
              at API project level.
           type: array
+          minItems: 1
           items:
             type: string
         config:

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -309,6 +309,7 @@ components:
              at API project level.
           type: array
           minItems: 1
+          maxItems: 1
           items:
             type: string
         config:
@@ -489,6 +490,7 @@ components:
              at API project level.
           type: array
           minItems: 1
+          maxItems: 1
           items:
             type: string
         config:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Limits the minimum & maximum of requested `types` - list to one item.


#### Which issue(s) this PR fixes:


Fixes #235 