### PR TITLE
Formatting correction in section 11.6.1 of API Design Guidelines

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1539,20 +1539,23 @@ where
 
 Regarding scope naming for APIs, which deal with explicit subscriptions, the guidelines propose some changes as compared to the above format, and this is described below:
 
-Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete:
+Scopes should be represented as below for APIs that offer explicit event subscriptions with action read and delete, for example:
 
-API Name: device-roaming-subscriptions
-Grant-level, action on resource: read, delete This type of formulation is not needed for the creation action.
-For e.g., device-roaming-subscriptions:read
+- API Name: `device-roaming-subscriptions`
+- Grant-level, action on resource: `read`, `delete` 
+
+results in scope: `device-roaming-subscriptions:read`.
+This type of formulation is not used for the creation action.
 
 The format to define scopes for explicit subscriptions with action creation,
 includes the event type in its formulation to ensure that consent is managed at the level of subscribed event types.
-Scopes should be represented as below for APIs that offer explicit event subscriptions with action create:
+Scopes should be represented as below for APIs that offer explicit event subscriptions with action create, for example:
 
-API Name: device-roaming-subscriptions
-Event-type: org.camaraproject.device-roaming-subscriptions.v0.roaming-on
-Grant-level: action on resource: create
-For e.g., device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create
+- API Name: `device-roaming-subscriptions`
+- Event-type: `org.camaraproject.device-roaming-subscriptions.v0.roaming-on`
+- Grant-level: action on resource: `create`
+
+makes scope name: `device-roaming-subscriptions:org.camaraproject.device-roaming-subscriptions.v0.roaming-on:create`.
 
 ##### API-level scopes (sometimes referred to as wildcard scopes in CAMARA)
 


### PR DESCRIPTION
#### What type of PR is this?

* correction


#### What this PR does / why we need it:
Better formatting to show how the security scope names are constructed for subscriptions.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #252 

#### Special notes for reviewers:



#### Changelog input

```
Formatting corrected in section 11.6.1 of API Design Guidelines

```

#### Additional documentation 

