### PR TITLE
Common 'area' data-type

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -168,7 +168,7 @@ components:
               minimum: 1
 
     Polygon:
-      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersection itself.
+      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersect itself.
       allOf:
         - $ref: "#/components/schemas/Area"
         - type: object

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -126,7 +126,7 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
-      
+
     Area:
       description: Base schema for all areas
       type: object

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -126,6 +126,94 @@ components:
       type: string
       format: ipv6
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+      
+    Area:
+      description: Base schema for all areas
+      type: object
+      properties:
+        areaType:
+          $ref: "#/components/schemas/AreaType"
+      required:
+        - areaType
+      discriminator:
+        propertyName: areaType
+        mapping:
+          CIRCLE: "#/components/schemas/Circle"
+          POLYGON: "#/components/schemas/Polygon"
+
+    AreaType:
+      type: string
+      description: |
+        Type of this area.
+        CIRCLE - The area is defined as a circle.
+        POLYGON - The area is defined as a polygon.
+      enum:
+        - CIRCLE
+        - POLYGON
+
+    Circle:
+      description: Circular area
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - center
+            - radius
+          properties:
+            center:
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Distance from the center in meters
+              minimum: 1
+
+    Polygon:
+      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersection itself.
+      allOf:
+        - $ref: "#/components/schemas/Area"
+        - type: object
+          required:
+            - boundary
+          properties:
+            boundary:
+              $ref: "#/components/schemas/PointList"
+
+    PointList:
+      description: List of points defining a polygon
+      type: array
+      items:
+        $ref: "#/components/schemas/Point"
+      minItems: 3
+      maxItems: 15
+
+    Point:
+      type: object
+      description: Coordinates (latitude, longitude) defining a location in a map
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example:
+        latitude: 50.735851
+        longitude: 7.10066
+
+    Latitude:
+      description: Latitude component of a location
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+
+    Longitude:
+      description: Longitude component of location
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
 
   responses:
     Generic400:


### PR DESCRIPTION
The PR adds a _Area_ Data Type to CAMARA_common.yaml, which is copied from the _location-retrieval_ API (Device Location). Variants of the Data Type are used by the _geofencing-subscriptions_ API (Device Location) and the _population-density-data_ API.
 
The PR is adding a consideration on self-intersecting polygons. 

#### What type of PR is this?

* documentation


#### What this PR does / why we need it:
The Area Data Type is used in multiple CAMARA APIs. 


#### Which issue(s) this PR fixes:
Fixes https://github.com/camaraproject/Commonalities/issues/242

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
a _Area_ Data Type to CAMARA_common.yaml, copied from the _location-retrieval_ API (Device Location)
```

#### Additional documentation 

This section is blank.


