### PR TITLE
Normalization of error status and code allowed values

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -303,11 +303,11 @@ components:
                 status: 404
                 code: NOT_FOUND
                 message: The specified resource is not found.
-            GENERIC_404_DEVICE_NOT_FOUND:
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
               description: Device identifier not found
               value:
                 status: 404
-                code: DEVICE_NOT_FOUND
+                code: IDENTIFIER_NOT_FOUND
                 message: Device identifier not found.
             GENERIC_404_{{SPECIFIC_CODE}}:
               description: Specific situation to highlight the resource/concept not found
@@ -503,36 +503,43 @@ components:
                       - 422
                   code:
                     enum:
-                      - DEVICE_IDENTIFIERS_MISMATCH
-                      - DEVICE_NOT_APPLICABLE
-                      - UNIDENTIFIABLE_DEVICE
-                      - UNSUPPORTED_DEVICE_IDENTIFIERS
+                      - IDENTIFIER_MISMATCH
+                      - SERVICE_NOT_APPLICABLE
+                      - UNIDENTIFIABLE_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
                       - "{{SPECIFIC_CODE}}"
           examples:
-            GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
-              description: Inconsistency between device identifiers not pointing to the same device
+            GENERIC_422_IDENTIFIER_MISMATCH:
+              description: Inconsistency between identifiers not pointing to the same device
               value:
                 status: 422
-                code: DEVICE_IDENTIFIERS_MISMATCH
-                message: Provided device identifiers are not consistent.
-            GENERIC_422_DEVICE_NOT_APPLICABLE:
-              description: Service is not available for the provided device
+                code: IDENTIFIER_MISMATCH
+                message: Provided identifiers are not consistent.
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service is not available for the provided identifier
               value:
                 status: 422
-                code: DEVICE_NOT_APPLICABLE
-                message: The service is not available for the provided device.
-            GENERIC_422_UNIDENTIFIABLE_DEVICE:
-              description: The device identifier is not included in the request and the device information cannot be derived from the 3-legged access token
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_UNIDENTIFIABLE_IDENTIFIER:
+              description: The identifier is not included in the request and the identifier information cannot be derived from the 3-legged access token
               value:
                 status: 422
-                code: UNIDENTIFIABLE_DEVICE
+                code: UNIDENTIFIABLE_IDENTIFIER
                 message: The device cannot be identified.
-            GENERIC_422_UNSUPPORTED_DEVICE_IDENTIFIERS:
-              description: None of the provided device identifiers is supported by the implementation
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
               value:
                 status: 422
-                code: UNSUPPORTED_DEVICE_IDENTIFIERS
-                message: The device provided is not supported.            
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when an API subject has already been identified from the access token
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The device is already identified by the access token.
             GENERIC_422_{{SPECIFIC_CODE}}:
               description: Any semantic condition associated to business logic, specifically related to a field or data structure
               value:

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -456,7 +456,7 @@ components:
                       - FAILED_PRECONDITION
           examples:
             GENERIC_412_FAILED_PRECONDITION:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
+              description: Indication by the API Server that the request cannot be processed in current system state
               value:
                 status: 412
                 code: FAILED_PRECONDITION

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -505,7 +505,7 @@ components:
                     enum:
                       - IDENTIFIER_MISMATCH
                       - SERVICE_NOT_APPLICABLE
-                      - UNIDENTIFIABLE_IDENTIFIER
+                      - MISSING_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
                       - UNNECESSARY_IDENTIFIER
                       - "{{SPECIFIC_CODE}}"
@@ -522,11 +522,11 @@ components:
                 status: 422
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
-            GENERIC_422_UNIDENTIFIABLE_IDENTIFIER:
+            GENERIC_422_MISSING_IDENTIFIER:
               description: The identifier is not included in the request and the identifier information cannot be derived from the 3-legged access token
               value:
                 status: 422
-                code: UNIDENTIFIABLE_IDENTIFIER
+                code: MISSING_IDENTIFIER
                 message: The device cannot be identified.
             GENERIC_422_UNSUPPORTED_IDENTIFIER:
               description: None of the provided identifiers is supported by the implementation
@@ -538,7 +538,7 @@ components:
               description: An explicit identifier is provided when an API subject has already been identified from the access token
               value:
                 status: 422
-                code: UNSUPPORTED_IDENTIFIER
+                code: UNNECESSARY_IDENTIFIER
                 message: The device is already identified by the access token.
             GENERIC_422_{{SPECIFIC_CODE}}:
               description: Any semantic condition associated to business logic, specifically related to a field or data structure

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.6.0-alpha
+  version: wip
   x-camara-commonalities: wip
   
 paths: {}

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -5,8 +5,8 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.5.0
-  x-camara-commonalities: 0.4.0
+  version: 0.6.0-alpha
+  x-camara-commonalities: wip
   
 paths: {}
 components:
@@ -128,6 +128,44 @@ components:
       example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
 
   responses:
+#######################################################
+#######################################################
+# ERROR RESPONSE SCHEMA TEMPLATE
+#   - Objective: Make normative error `status` and `code` values
+#   - Schema Template rationale:
+#     - The `allOf` in content.application/json.schema allows a combination of both the generic ErrorInfo schema and the specific schema for this error response,
+#       which validates that `status` and `code` have only the specified values.
+#       This `allOf` is used without discriminator because it does not imply any hierarchy between the models, just 2 schemas that must be independently validated.
+#######################################################
+#    ErrorResponseSchema:
+#      ...
+#      content:
+#        application/json:
+#          schema:
+#            allOf:
+#              - $ref: '#/components/schemas/ErrorInfo'
+#              - type: object
+#                properties:
+#                  status:
+#                    enum:
+#                      - <status>
+#                  code:
+#                    enum:
+#                      - <code1>
+#                      - <code2>
+#          examples:
+#            ExampleKey1:
+#              value:
+#                status: <status>
+#                code: <code1>
+#                message: <message1>
+#            ExampleKey2:
+#              value:
+#                status: <status>
+#                code: <code2>
+#                message: <message2>
+#######################################################
+#######################################################
     Generic400:
       description: Bad Request
       headers:
@@ -136,7 +174,18 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -164,7 +213,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
               description: Request cannot be authenticated
@@ -186,7 +245,18 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+                      - INVALID_TOKEN_CONTEXT
+                      - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -214,7 +284,18 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - DEVICE_NOT_FOUND
+                      - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_404_NOT_FOUND:
               description: Resource is not found
@@ -242,7 +323,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 405
+                  code:
+                    enum:
+                      - METHOD_NOT_ALLOWED
           examples:
             GENERIC_405_METHOD_NOT_ALLOWED:
               description: Invalid HTTP verb used with a given endpoint
@@ -258,7 +348,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 406
+                  code:
+                    enum:
+                      - NOT_ACCEPTABLE
           examples:
             GENERIC_406_NOT_ACCEPTABLE:
               description: API Server does not accept the media type (`Accept-*` header) indicated by API client
@@ -274,7 +373,19 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - ABORTED
+                      - ALREADY_EXISTS
+                      - CONFLICT
+                      - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_409_ABORTED:
               description: Concurreny of processes of the same nature/scope
@@ -308,7 +419,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
           examples:
             GENERIC_410_GONE:
               description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
@@ -324,7 +444,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 412
+                  code:
+                    enum:
+                      - FAILED_PRECONDITION
           examples:
             GENERIC_412_FAILED_PRECONDITION:
               description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
@@ -340,7 +469,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 415
+                  code:
+                    enum:
+                      - UNSUPPORTED_MEDIA_TYPE
           examples:
             GENERIC_415_UNSUPPORTED_MEDIA_TYPE:
               description: Payload format of the request is in an unsupported format by the Server. Should not happen
@@ -356,7 +494,20 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - DEVICE_IDENTIFIERS_MISMATCH
+                      - DEVICE_NOT_APPLICABLE
+                      - UNIDENTIFIABLE_DEVICE
+                      - UNSUPPORTED_DEVICE_IDENTIFIERS
+                      - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_422_DEVICE_IDENTIFIERS_MISMATCH:
               description: Inconsistency between device identifiers not pointing to the same device
@@ -376,6 +527,12 @@ components:
                 status: 422
                 code: UNIDENTIFIABLE_DEVICE
                 message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_DEVICE_IDENTIFIERS:
+              description: None of the provided device identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_DEVICE_IDENTIFIERS
+                message: The device provided is not supported.            
             GENERIC_422_{{SPECIFIC_CODE}}:
               description: Any semantic condition associated to business logic, specifically related to a field or data structure
               value:
@@ -390,7 +547,17 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
           examples:
             GENERIC_429_QUOTA_EXCEEDED:
               description: Request is rejected due to exceeding a business quota limit
@@ -412,7 +579,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 500
+                  code:
+                    enum:
+                      - INTERNAL
           examples:
             GENERIC_500_INTERNAL:
               description: Problem in Server side. Regular Server Exception
@@ -428,7 +604,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 501
+                  code:
+                    enum:
+                      - NOT_IMPLEMENTED
           examples:
             GENERIC_501_NOT_IMPLEMENTED:
               description: Service not implemented. The use of this code should be avoided as far as possible to get the objective to reach aligned implementations
@@ -444,7 +629,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 502
+                  code:
+                    enum:
+                      - BAD_GATEWAY
           examples:
             GENERIC_502_BAD_GATEWAY:
               description: Internal routing problem in the Server side that blocks to manage the service properly
@@ -460,7 +654,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 503
+                  code:
+                    enum:
+                      - SERVICE_UNAVAILABLE
           examples:
             GENERIC_503_UNAVAILABLE:
               description: Service is not available. Temporary situation usually related to maintenance process in the server side
@@ -476,7 +679,16 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorInfo"
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 504
+                  code:
+                    enum:
+                      - TIMEOUT
           examples:
             GENERIC_504_TIMEOUT:
               description: API Server Timeout

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -294,7 +294,7 @@ components:
                   code:
                     enum:
                       - NOT_FOUND
-                      - DEVICE_NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
                       - "{{SPECIFIC_CODE}}"
           examples:
             GENERIC_404_NOT_FOUND:

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -701,6 +701,8 @@ An error representation must not be different from the representation of any res
 All these aforementioned fields are mandatory in Error Responses.
 `status` and `code` fields have normative nature, so as their use has to be standardized (see [Section 6.1](#61-standardized-use-of-camara-error-responses)). On the other hand, `message` is informative and within this document an example is shown.
 
+Fields `status` and `code` values are normative (i.e. they have a set of allowed values), as defined in [CAMARA_common.yaml](../artifacts/CAMARA_common.yaml).
+
 A JSON error structure is proposed below: 
 
 ```json
@@ -790,7 +792,7 @@ The Following table compiles the guidelines to be adopted:
 | **Case #** | **Description**                                                            | **Error status** |         **Error code**         | **Message example**                                      |
 |:----------:|:---------------------------------------------------------------------------|:----------------:|:------------------------------:|:---------------------------------------------------------|
 |     0      | The request body does not comply with the schema                           |       400        |        INVALID_ARGUMENT        | Request body does not comply with the schema.            |
-|     1      | None of the provided device identifiers is supported by the implementation |       422        | UNSUPPORTED_DEVICE_IDENTIFIERS | phoneNumber is required.                                 |
+|     1      | None of the provided device identifiers is supported by the implementation |       422        | UNSUPPORTED_DEVICE_IDENTIFIERS | The device provided is not supported.                                 |
 |     2      | Some identifier cannot be matched to a device                              |       404        |        DEVICE_NOT_FOUND        | Device identifier not found.                             |  
 |     3      | Device identifiers mismatch                                                |       422        |  DEVICE_IDENTIFIERS_MISMATCH   | Provided device identifiers are not consistent.          |
 |     4      | Invalid access token context                                               |       403        |     INVALID_TOKEN_CONTEXT      | Device identifiers are not consistent with access token. |
@@ -814,7 +816,17 @@ headers:
 content:
   application/json:
     schema:
-      $ref: "#/components/schemas/ErrorInfo"
+      allOf:
+        - $ref: "#/components/schemas/ErrorInfo"
+        - type: object
+          properties:
+            status:
+              enum:
+                - <status>
+            code:
+              enum:
+                - <code1>
+                - <code2>
     examples:
       {{case_1}}:
         $ref: ""#/components/examples/{{case_1}}"

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -792,7 +792,7 @@ The Following table compiles the guidelines to be adopted:
 | **Case #** | **Description**                                                            | **Error status** |         **Error code**         | **Message example**                                      |
 |:----------:|:---------------------------------------------------------------------------|:----------------:|:------------------------------:|:---------------------------------------------------------|
 |     0      | The request body does not comply with the schema                           |       400        |        INVALID_ARGUMENT        | Request body does not comply with the schema.            |
-|     1      | None of the provided device identifiers is supported by the implementation |       422        | UNSUPPORTED_DEVICE_IDENTIFIERS | The device provided is not supported.                                 |
+|     1      | None of the provided device identifiers is supported by the implementation |       422        |     UNSUPPORTED_IDENTIFIER     | The identifier provided is not supported.                                 |
 |     2      | Some identifier cannot be matched to a device                              |       404        |        DEVICE_NOT_FOUND        | Device identifier not found.                             |  
 |     3      | Device identifiers mismatch                                                |       422        |  DEVICE_IDENTIFIERS_MISMATCH   | Provided device identifiers are not consistent.          |
 |     4      | Invalid access token context                                               |       403        |     INVALID_TOKEN_CONTEXT      | Device identifiers are not consistent with access token. |


### PR DESCRIPTION
#### What type of PR is this?

* correction
* enhancement


#### What this PR does / why we need it:

This PR aims to define a normalization of error `status` and `code` allowed values for CAMARA APIs, by means of the use of a common chema model that can be applied for every excepction scenario.

Taking advantage of this PR also a correction is managed:
- `422 UNSUPPORTED_DEVICE_IDENTIFIERS` exception renamed to `422 UNSUPPORTED_IDENTIFIER` indicated in API Design guidelines is also included in `CAMARA_common.yaml`

- Also making exceptions alignment as per [this](https://github.com/camaraproject/Commonalities/issues/321#issuecomment-2429158445) comment in `CAMARA_common.yaml`. Updates in API Design guidelines Section 6.2 will be managed by #324 and #329


#### Which issue(s) this PR fixes:

Fixes #196 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:

Documentation impacted:
- [API-Testing-Guidelines.md](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-Testing-Guidelines.md)
- [CAMARA_common.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml)

Once this PR is agreed (i.e. the baseline), other artifacts would have to be updated:
- [notification-as-cloud-event.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/notification-as-cloud-event.yaml)
- [event-subscription-template.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/camara-cloudevents/event-subscription-template.yaml)

We can talk this point in the next commonalities meeting (14/10) and aligned this with @bigludo7 


#### Changelog input

```
Normalization of error `status` and `code` allowed values for CAMARA APIs.

```


#### Additional documentation 

N/A

