### PR TITLE
Filtering for boolean

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -925,7 +925,7 @@ And according to the filtering based on string and enums data, being searched fo
 
 For boolean parameters the filter can be set for True or False value:
 
-| **Operation** | 	**Strings/enums**    |
+| **Operation** | 	**Booleans**    |
 |---------------|-----------------------|
 | True          | `GET .../?boolAttr=true`  |
 | False         | `GET .../?boolAttr=false` |

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -923,6 +923,13 @@ And according to the filtering based on string and enums data, being searched fo
 | non equal     | `GET .../?name!=Jonh` |
 | Contains      | `GET .../?name=~Rafa` |
 
+For boolean parameters the filter can be set for True or False value:
+
+| **Operation** | 	**Strings/enums**    |
+|---------------|-----------------------|
+| True          | `GET .../?boolAttr=true`  |
+| False         | `GET .../?boolAttr=false` |
+
 
 **Additional rules**:
 - The operator "`&`" is evaluated as an AND between different attributes.

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -936,6 +936,11 @@ As filtering may reveal sensitive information, privacy and security constraints 
 
 And according to the filtering based on string and enums data, being searched for: 
 
+| **Operation** |	**Strings/enums** |
+| ----- | ----- |
+| equal | `GET .../?type=mobile` |
+| non equal | `GET .../?type!=mobile` |
+| Contains | `GET .../?type=~str` |
 
 For boolean parameters the filter can be set for True or False value:
 
@@ -943,8 +948,6 @@ For boolean parameters the filter can be set for True or False value:
 |---------------|-----------------------|
 | True          | `GET .../?boolAttr=true`  |
 | False         | `GET .../?boolAttr=false` |
-
-
 
 **Additional rules**:
 - The operator "`&`" is evaluated as an AND between different attributes.


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:
Adds indications how to formulate filter criteria for boolean-valued attributes.
`boolAttr=true&...` and `boolAttr=false&...` is proposed in 8.3 of API Design Guidelines


#### Which issue(s) this PR fixes:

Fixes #130


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
Filtering for boolean values added to  API Design Guidelines.

```

#### Additional documentation 
