### PR TITLE
Error alignments for Event Notifications Artifact

### DIFF
--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -101,10 +101,6 @@ paths:
           $ref: "#/components/responses/Generic410"
         429:
           $ref: "#/components/responses/Generic429"
-        500:
-          $ref: "#/components/responses/Generic500"
-        503:
-          $ref: "#/components/responses/Generic503"
 components:
   securitySchemes:
     notificationsBearerAuth:

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1965,7 +1965,7 @@ Note: The "subscription-ends" notification is not counted in the `subscriptionMa
 Error definitions are described in this guideline applies for event notification.
 
 The Following Error codes must be present:
-* for `POST`: 400, 401, 403, 500, 503
+* for `POST`: 400, 401, 403, 410, 429
 
 #### Correlation Management
 To manage correlation between the subscription management and the event notification (as these are two distinct operations):


### PR DESCRIPTION
#### What type of PR is this?

* correction


#### What this PR does / why we need it:

This PR provides an aligment for CAMARA event notifications artifact in terms of documented errors and also API Design guidelines for mandatory errors for this artifact.

Rational is detailed in #348

Mandatory/Documented errors are proposed to be: 400, 401, 403, 410, 429. Documents impacted:

- [CAMARA Event Notifications artifact](https://github.com/camaraproject/Commonalities/blob/main/artifacts/notification-as-cloud-event.yaml#L88)

- [API Design guidelines ](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-design-guidelines.md#error-definition-for-event-notification)

#### Which issue(s) this PR fixes:

Fixes #348


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:



#### Changelog input

```
Error alignments for Event Notifications Artifact in MetaRelease Spring 25

```

#### Additional documentation 

N/A
