### PR TITLE
Update rules when using POST for sensitive data

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -301,7 +301,9 @@ In such cases, it is recommended to use one of the following methods to transfer
 - When using `GET`, transfer the data using headers, which are not routinely logged or cached
 - Use `POST` instead of `GET`, with the sensitive data being embedded in the request body which, again, is not routinely logged or cached 
 
-When the `POST` method is used, the resource in the path *must* be a verb (e.g. `retrieve-location` and not `location`) to differentiate from an actual resource creation.
+When the `POST` method is used:
+- the resource in the path MUST be a verb (e.g. `retrieve-location` and not `location`) to differentiate from an actual resource creation
+- the request body itself MUST be a JSON object and MUST be required, even if all properties are optional
 
 It is also fine to use POST instead of GET:
 - to bypass technical limitations, such as URL character limits (if longer than 4k characters) or passing complex objects in the request


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
The existing design guidelines allow the request body to be optional when using `POST` to transfer sensitive data. The changes mandate that the request body be present, even if no parameters need to be sent (e.g. if a 3-legged access token is used). In this case, and empty JSON object must be sent.

This change ensures that all APIs passing sensitive data using `POST` adopt a common design pattern.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #247

#### Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If indicated yes above, please describe the breaking change(s). -->
APIs with an optional `POST` request body must now make it mandatory, even if no parameters need to be sent

Note: I'm not aware of any current APIs that will be impacted by this change. Device Identifier has a PR which will make the request body mandatory.

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Update rules when using POST for sensitive data making request body mandatory
```

#### Additional documentation 
None