### PR TITLE
Correct CAMARA_common.yaml Generic503 error code to UNAVAILABLE, to match API design guidelines

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -768,7 +768,7 @@ components:
               description: Service is not available. Temporary situation usually related to maintenance process in the server side
               value:
                 status: 503
-                code: UNAVAILABLE
+                code: SERVICE_UNAVAILABLE
                 message: Service Unavailable.
     Generic504:
       description: Gateway Timeout

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -762,13 +762,13 @@ components:
                       - 503
                   code:
                     enum:
-                      - SERVICE_UNAVAILABLE
+                      - UNAVAILABLE
           examples:
             GENERIC_503_UNAVAILABLE:
               description: Service is not available. Temporary situation usually related to maintenance process in the server side
               value:
                 status: 503
-                code: SERVICE_UNAVAILABLE
+                code: UNAVAILABLE
                 message: Service Unavailable.
     Generic504:
       description: Gateway Timeout


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Generic503 definition in CAMARA_common.yaml uses code value `SERVICE_UNAVAILABLE` when defined code in API design guidelines is `UNAVAILABLE`

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->
Only a typo fix

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Correct CAMARA_common.yaml Generic503 error code to UNAVAILABLE
```

#### Additional documentation 
None