### PR TITLE
Disable info-contact rule for initial CAMARA API specification

### DIFF
--- a/artifacts/linting_rules/.spectral.yml
+++ b/artifacts/linting_rules/.spectral.yml
@@ -3,6 +3,7 @@
 # Changelog:
 # - 31.01.2024: Initial version
 # - 19.03.2024: Corrected camara-http-methods rule
+# - 30.12.2024: Updated info-contact rule
 
 
 extends: "spectral:oas"
@@ -16,7 +17,7 @@ rules:
   #  The severity keyword is optional in rule definition and can be error, warn, info, hint, or off. The default value is warn.
   contact-properties: false
   duplicated-entry-in-enum: true
-  info-contact: true
+  info-contact: false
   info-description: true
   info-license: true
   license-url: true


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

This PR disable the info-contact rule. 

#### Which issue(s) this PR fixes:

Fixes #

As discussed, and decided in the CAMARA Commonalities call, we need to disable the info-contact spectral rule because we are preparing the first version of the CAMARA API specification, where contact information is not required. After the API specification is finalized, the developers/Organization responsible for this API will add their contact details.
As per CAMARA standards 


#### Changelog input:
 30.12.2024: Updated info-contact rule