### PR TITLE
String pattern added to x-correlator scheme

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -19,6 +19,7 @@ components:
       description: Correlation id for the different services
       schema:
         type: string
+        pattern: ^[a-zA-Z0-9-]{1,55}$
   parameters:
     x-correlator:
       name: x-correlator
@@ -26,6 +27,7 @@ components:
       description: Correlation id for the different services
       schema:
         type: string
+        pattern: ^[a-zA-Z0-9-]{1,55}$
   schemas:
     TimePeriod:
       properties:

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -28,6 +28,7 @@ components:
       schema:
         type: string
         pattern: ^[a-zA-Z0-9-]{1,55}$
+        example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
   schemas:
     TimePeriod:
       properties:

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1044,9 +1044,9 @@ Then the parameters can be included in the query:
 
 With the aim of standardizing the request observability and traceability process, common headers that provide a follow-up of the E2E processes should be included. The table below captures these headers.
 
-| Name           | Description                                   | Type     | Location         | Required by API Consumer | Required in OAS Definition | 	Example                              | 
-|----------------|-----------------------------------------------|----------|------------------|--------------------------|----------------------------|---------------------------------------|
-| `x-correlator` | 	Service correlator to make E2E observability | 		String | Request/Response | No                       | Yes                        | 	b4333c46-49c0-4f62-80d7-f0ef930f1c46 |
+| Name           | Description                                   | Schema          | Location         | Required by API Consumer | Required in OAS Definition | 	Example                              | 
+|----------------|-----------------------------------------------|----------------------|------------------|--------------------------|----------------------------|----------------------------------------|
+| `x-correlator` | 	Service correlator to make E2E observability | `type: string`  `pattern: ^[a-zA-Z0-9-]{1,55}$`     | Request / Response | No                       | Yes                        | 	b4333c46-49c0-4f62-80d7-f0ef930f1c46 |
 
 When the API Consumer includes the "x-correlator" header in the request, the API provider must include it in the response with the same value that was used in the request. Otherwise, it is optional to include the "x-correlator" header in the response with any valid value. Recommendation is to use UUID for values.
 


### PR DESCRIPTION
#### What type of PR is this?
* correction


#### What this PR does / why we need it:

String pattern added to x-correlator scheme to improve security and inline with current recommendation for string parameters.
The proposed pattern covers recommended UUID strings and the length of 55 allows to use strings similar to  `traceparent` from Trace Context.

CAMARA_common.yaml was updated accordingly.


#### Which issue(s) this PR fixes:

Fixes #352 


#### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
The change should not be breaking for current implementations using UUID in x-correlator.


#### Changelog input

```
String pattern added to x-correlator scheme

```

#### Additional documentation 


