### PR TITLE
Clarification on non-mandatory error statuses, 429 made non-madatory

### DIFF
--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -803,6 +803,7 @@ In the following, we elaborate on the existing client errors. In particular, we 
 - For the rest of APIs:
   - Error status 401
   - Error status 403
+  - Error status 501, if and only if an endpoint is optional for implementations
 
 NOTE:
 The documentation of non-mandatory error statuses defined in section 6.1 depends on the specific considerations and design of the given API.

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -805,7 +805,11 @@ In the following, we elaborate on the existing client errors. In particular, we 
   - Error status 403
   - Error status 429 TOO_MANY_REQUESTS (For rate limit control)
 
-NOTE: The remaining Error statuses defined in section 6.1 will be documented based on specific considerations for the given API.
+NOTE:
+The documentation of non-mandatory error statuses defined in section 6.1 depends on the specific considerations and design of the given API.
+ - Error statuses 400, 404, 409, 422: These error statuses should be documented based on the API design and the functionality involved. Subproject evaluate the relevance and necessity of including these statuses in API specifications.
+ - Error statuses 405, 406, 410, 412, 415, and 5xx: These error statuses are not documented by default in the API specification. However, they should be included if there is a relevant use case that justifies their documentation. 
+
 
 ### 6.2 Error Responses - Device Object/Phone Number
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -807,7 +807,7 @@ In the following, we elaborate on the existing client errors. In particular, we 
 
 NOTE:
 The documentation of non-mandatory error statuses defined in section 6.1 depends on the specific considerations and design of the given API.
- - Error statuses 400, 404, 409, 422: These error statuses should be documented based on the API design and the functionality involved. Subproject evaluate the relevance and necessity of including these statuses in API specifications.
+ - Error statuses 400, 404, 409, 422: These error statuses should be documented based on the API design and the functionality involved. Subprojects evaluate the relevance and necessity of including these statuses in API specifications.
  - Error statuses 405, 406, 410, 412, 415, and 5xx: These error statuses are not documented by default in the API specification. However, they should be included if there is a relevant use case that justifies their documentation. 
 
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -803,11 +803,10 @@ In the following, we elaborate on the existing client errors. In particular, we 
 - For the rest of APIs:
   - Error status 401
   - Error status 403
-  - Error status 429 TOO_MANY_REQUESTS (For rate limit control)
 
 NOTE:
 The documentation of non-mandatory error statuses defined in section 6.1 depends on the specific considerations and design of the given API.
- - Error statuses 400, 404, 409, 422: These error statuses should be documented based on the API design and the functionality involved. Subprojects evaluate the relevance and necessity of including these statuses in API specifications.
+ - Error statuses 400, 404, 409, 422, 429: These error statuses should be documented based on the API design and the functionality involved. Subprojects evaluate the relevance and necessity of including these statuses in API specifications.
  - Error statuses 405, 406, 410, 412, 415, and 5xx: These error statuses are not documented by default in the API specification. However, they should be included if there is a relevant use case that justifies their documentation. 
 
 

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -803,12 +803,14 @@ In the following, we elaborate on the existing client errors. In particular, we 
 - For the rest of APIs:
   - Error status 401
   - Error status 403
-  - Error status 501, if and only if an endpoint is optional for implementations
 
 NOTE:
 The documentation of non-mandatory error statuses defined in section 6.1 depends on the specific considerations and design of the given API.
  - Error statuses 400, 404, 409, 422, 429: These error statuses should be documented based on the API design and the functionality involved. Subprojects evaluate the relevance and necessity of including these statuses in API specifications.
- - Error statuses 405, 406, 410, 412, 415, and 5xx: These error statuses are not documented by default in the API specification. However, they should be included if there is a relevant use case that justifies their documentation. 
+ - Error statuses 405, 406, 410, 412, 415, and 5xx: These error statuses are not documented by default in the API specification. However, they should be included if there is a relevant use case that justifies their documentation.
+   - Special Consideration for error 501 NOT IMPLEMENTED to indicate optional endpoint:
+     - The use of optional endpoints is discouraged in order to have aligned implementations
+     - Only for exceptions where an optional endpoint can not be avoided and defining it in separate, atomic API is not possible - error status 501 should be documented as a valid response
 
 
 ### 6.2 Error Responses - Device Object/Phone Number


### PR DESCRIPTION
#### What type of PR is this?
* correction


#### What this PR does / why we need it:
Clarification proposed in the issue discussion #355.
429 made non-madatory - #365 
501 mandatory, if and only if an endpoint is optional for implementations


#### Which issue(s) this PR fixes:

Fixes #355 #365 #246


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
The discussion in #355 concludes to keep the error definitions in CAMARA_common.yaml.
Adding comments to each error schema (saying if it is mandatory) can be considered.


#### Changelog input

```
Added clarification on non-mandatory error statuses

```

#### Additional documentation 

This section can be blank.



```
docs

```
