### PR TITLE
Change guidelines on `x-camara-commonalities` extension field

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -6,7 +6,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.6.0-alpha.1
-  x-camara-commonalities: 0.5.0
+  x-camara-commonalities: 0.5
   
 paths: {}
 components:

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.2.0-alpha.1
-  x-camara-commonalities: 0.5.0
+  x-camara-commonalities: 0.5
   
 externalDocs:
   description: Product documentation at CAMARA

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1325,13 +1325,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  # CAMARA Commonalities version - x.y.z
-  x-camara-commonalities: 0.4.0
+  # CAMARA Commonalities minor version - x.y
+  x-camara-commonalities: 0.4
 ```
 
 The `termsOfService` and `contact` fields are optional in OpenAPI specification and may be added by API Providers documenting their APIs.
 
-The extension field `x-camara-commonalities` indicates a version of CAMARA Commonalities guidelines that given API specification adheres to.
+The extension field `x-camara-commonalities` indicates a minor version of CAMARA Commonalities guidelines that given API specification adheres to.
 
 
 #### Servers object

--- a/documentation/API-design-guidelines.md
+++ b/documentation/API-design-guidelines.md
@@ -1326,7 +1326,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   # CAMARA Commonalities minor version - x.y
-  x-camara-commonalities: 0.4
+  x-camara-commonalities: 0.5
 ```
 
 The `termsOfService` and `contact` fields are optional in OpenAPI specification and may be added by API Providers documenting their APIs.


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:
 Change of `x-camara-commonalities` field from `info` object definition, to include only minor version (without patch), as it was hard to maintain in subprojects esp. when Commonalities produce patch release. 


#### Which issue(s) this PR fixes:

Fixes #327 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
Removing `x-camara-commonalities` field from `info` object definition in API Design Guidelines can also be considered.


#### Changelog input

Changed guidelines on `x-camara-commonalities` extension field


#### Additional documentation 

This section can be blank.


