### PR TITLE
Remove sinkCredential from Subscription schema in event-subscription-template.yaml

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -467,8 +467,6 @@ components:
           format: url
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          $ref: '#/components/schemas/SinkCredential'
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Remove sinkCredential from Subscription schema in event-subscription-template.yaml as it cannot be used

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #399

#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->
Note: anyone who was returning sink credentials in responses might complain this breaks their implementation, but they should not have been doing that anyway

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Remove sinkCredential from Subscription schema in event-subscription-template.yaml
```

#### Additional documentation 
None
