### PR TITLE
Spring 25 Commonalities Artifacts version reset after Pre-release generation

### DIFF
--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.5.0-rc.1
+version: wip

--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.6.0-rc.1
+  version: wip
   x-camara-commonalities: 0.5
   
 paths: {}

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0-rc.1
+  version: wip
   x-camara-commonalities: 0.5
   
 externalDocs:

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -42,7 +42,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.2.0-rc.1
+  version: wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

CAMARA comminalities artifacts version reset after Pre-Release generation - [r2.2](https://github.com/camaraproject/Commonalities/releases/tag/r2.2)


#### Which issue(s) this PR fixes:

Fixes #402


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


#### Special notes for reviewers:

N/A

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
