### PR TITLE
fix: correct the format for the "sink" to "uri"

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -479,7 +479,7 @@ components:
           $ref: "#/components/schemas/Protocol"
         sink:
           type: string
-          format: url
+          format: uri
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:


### PR DESCRIPTION
#### What type of PR is this?

<!-- Add one of the following kinds: -->

* correction

#### What this PR does / why we need it:
Fixes the format for the `sink`-property in the `Subscription`-response.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #420 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


#### Changelog input

```
 release-note
* correct the format for the "sink" to "uri"
```

