### PR TITLE
Update maintainers and codeonwers after Spring25

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @shilpa-padgaonkar @rartych @patrice-conil @RubenBG7 @PedroDiez 
+* @shilpa-padgaonkar @rartych @patrice-conil @PedroDiez @jlurien
 
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -3,3 +3,4 @@
 | Deutsche Telekom | Rafal Artych | rartych |
 | Deutsche Telekom | Shilpa Padgaonkar | shilpa-padgaonkar |
 | Vodafone | Eric Murray |  eric-murray |
+| Telefonica | Pedro Díez | PedroDiez |


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

Update of maintainers and codeowners after Spring25.
Changes from TEF indicated so far. Other volunteers are welcome. 


#### Which issue(s) this PR fixes:

Fixes #425


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:

Keep open until next Commonalities meeting (17/03) for any additional volunteer.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
