### PR TITLE
Align 401 wording in Notification Cloud Events Artifact

### DIFF
--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -243,11 +243,11 @@ components:
                       - UNAUTHENTICATED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
     Generic403:
       description: Client does not have sufficient permission
       headers:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Complementary to PR #429. In order to align 401 UNAUTHENTICATED wording in [notification-as-cloud-event.yaml](https://github.com/camaraproject/Commonalities/blob/main/artifacts/notification-as-cloud-event.yaml#L245)


#### Which issue(s) this PR fixes:

Fixes #368 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


#### Special notes for reviewers:
N/A


#### Changelog input

```
 release-note
 - Align 401 UNAUTHENTICATED wording in notification-as-cloud-event.yaml artifact
```

#### Additional documentation 

N/A



```
docs

```
