### PR TITLE
Links to CAMARA API Event Subscription and Notification Guide in artifacts

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -2,7 +2,8 @@ openapi: 3.0.3
 info:
   title: Notification Subscription Template
   description: |
-    This file is a template for CAMARA API explicit subscription endpoint and for Notification model. Additional information are provided in API Design Guidelines document.
+    This file is a template for CAMARA API explicit subscription endpoint and for Notification model.
+    Additional information are provided in [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md).
 
     Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<api-version>.<event-name>``
 

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -34,7 +34,8 @@ info:
     # API Functionality
     
     Only one endpoint/operation is provided: `POST /your_webhook_notification_url`
-    This endpoint describes the event notification received on subscription listener side when the event occurred. A detailed description of the event notification is provided in the CAMARA API design guideline document.
+    This endpoint describes the event notification received on subscription listener side when the event occurred. 
+    A detailed description of the event notification is provided in the [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md#3-event-notification)
 
   termsOfService: http://swagger.io/terms/
   contact:


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

References to [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md) are added to `event-subscription-template.yaml` and `notification-as-cloud-event.yaml`


#### Which issue(s) this PR fixes:

Fixes #290 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
References to [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md)  added to event-subscription-template.yaml and notification-as-cloud-event.yaml

```

#### Additional documentation 

This section can be blank.



```
docs

```
