### PR TITLE
Text description aligment for duration format fields

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -98,7 +98,8 @@ This part captures a detailed description of all the data structures used in the
 
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
   - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
-    - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time. Use of a start date or time string field in combination with duration string field could help to mitigate ambiguity issues.
+    - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time. Use of a start date or time string field in combination with the duration string field could help to mitigate ambiguity issues.
+
 
 
 - If the data type is an object, list of required properties.

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -96,7 +96,8 @@ This part captures a detailed description of all the data structures used in the
 - Data type (String, Integer, Object…).
 - If the data type is string it is recommended to use appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
-  - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
+  - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration` - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time.
+
 
 - If the data type is an object, list of required properties.
 - List of properties within the object data, including:

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -96,6 +96,7 @@ This part captures a detailed description of all the data structures used in the
 - Data type (String, Integer, Object…).
 - If the data type is string it is recommended to use appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
+  - If the format of a string is duration, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
 - If the data type is an object, list of required properties.
 - List of properties within the object data, including:
    - Property name

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -96,7 +96,8 @@ This part captures a detailed description of all the data structures used in the
 - Data type (String, Integer, Object…).
 - If the data type is string it is recommended to use appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
-  - If the format of a string is duration, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
+  - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
+
 - If the data type is an object, list of required properties.
 - List of properties within the object data, including:
    - Property name

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -100,8 +100,6 @@ This part captures a detailed description of all the data structures used in the
   - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
     - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time. Use of a start date or time string field in combination with the duration string field could help to mitigate ambiguity issues.
 
-
-
 - If the data type is an object, list of required properties.
 - List of properties within the object data, including:
    - Property name

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -94,7 +94,8 @@ This repository is referenced below.
 This part captures a detailed description of all the data structures used in the API specification. For each of these data, the specification must contain:
 - Name of the data object, used to reference it in other sections.
 - Data type (String, Integer, Object…).
-- If the data type is string it is recommended to use appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
+- If the data type is string it is recommended to use the appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
+
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
   - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
     - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time. Use of a start date or time string field in combination with duration string field could help to mitigate ambiguity issues.

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -96,7 +96,8 @@ This part captures a detailed description of all the data structures used in the
 - Data type (String, Integer, Object…).
 - If the data type is string it is recommended to use appropriate modifier property `format` and/or `pattern` whenever possible. The [OpenAPI Initiative Formats Registry](https://spec.openapis.org/registry/format/) contains the list of formats used in OpenAPI specifications.
   - If the format of a string is `date-time`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)`
-  - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration` - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time.
+  - If the format of a string is `duration`, the following sentence must be present in the description: `It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#appendix-A) for duration`
+    - Note: to avoid known ambiguity issues with duration strings, consider using intervals, which are anchored to a specific start and end date or time. Use of a start date or time string field in combination with duration string field could help to mitigate ambiguity issues.
 
 
 - If the data type is an object, list of required properties.


### PR DESCRIPTION
#### What type of PR is this?

* enhancement


#### What this PR does / why we need it:

Provide an aligned text description for duration format fields as explained in #458.
In this way, it avoids additional WG discusions on which description text use.


#### Which issue(s) this PR fixes:

Fixes #458


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:

Suggested Note added just to inform Subproject about ambigüity that may generate use of duration fields. 
Also use of a start date/time field in combination with a `duration` format field could help to mitigate ambiguity topics (added also to inform Subproject, at the end it will be up to their consideration) .

Info about this:
- Claude AI: https://claude.ai/share/2713ae90-eb87-4a76-b316-2c968309668e
- GitHub Copilot: https://github.com/copilot/c/795562aa-d96a-4d35-a96a-88c38595f1e8


#### Changelog input

```
 Text description alignment for duration format fields

```

#### Additional documentation 

This section can be blank.



```
docs

```
