### PR TITLE
Update of .gherkin-lintrc

### DIFF
--- a/artifacts/linting_rules/.gherkin-lintrc
+++ b/artifacts/linting_rules/.gherkin-lintrc
@@ -23,11 +23,11 @@
     }
   ],
   "no-trailing-spaces": "on",
-  "new-line-at-eof": ["on", "no"],
+  "new-line-at-eof": ["off", "yes"],
   "no-multiple-empty-lines": "on",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",
-  "name-length": ["on", {"Feature": 90, "Step": 190, "Scenario": 190}],
+  "name-length": ["on", {"Feature": 190, "Step": 190, "Scenario": 190}],
   "no-restricted-tags": ["on", {"tags": ["@watch", "@wip"]}],
   "use-and": "on",
   "keywords-in-logical-order": "on",


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Fixes for linting rules for Gherkin files - test definitions:
 - unification of name lengths
 - switching off `new-line-at-eof` rule


#### Which issue(s) this PR fixes:

Fixes #465 #469 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:

If other rules can be updated or simplfied, please add your comments. 



#### Changelog input

```
Updated .gherkin-lintrc

```

