### PR TITLE
Remove IDENTIFIER_MISMATCH from testing artifacts

### DIFF
--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -13,22 +13,27 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     * These scenarios assume that other properties not explicitly mentioned in the scenario
     are set by default to a valid value. This can be specified in the feature Background.
 
-    * {{feature_identifier}} has to be substituted to the value corresponding to the feature file where
+    * {feature_identifier} has to be substituted to the value corresponding to the feature file where
     these scenarios are included.
+
+    * {operationId} has to be substituted to the value of operationId for the tested operation
+
+    * {path_to_device} has to be substituted to the JSON path of the device property in the body request, typically 
+    "$.device" or "$.config.subscriptionDetail.device" for Subscription APIs
 
     # Error scenarios for management of input parameter device
 
-    @{{feature_identifier}}_C01.01_device_empty
+    @{feature_identifier}_C01.01_device_empty
     Scenario: The device value is an empty object
         Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "$.device" is set to: {}
+        And the request body property "{path_to_device}" is set to: {}
         When the request "{operationId}" is sent
         Then the response status code is 400
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @{{feature_identifier}}_C01.02_device_identifiers_not_schema_compliant
+    @{feature_identifier}_C01.02_device_identifiers_not_schema_compliant
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
@@ -39,48 +44,48 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
         And the response property "$.message" contains a user friendly text
         
         Examples:
-            | device_identifier          | oas_spec_schema                             |
-            | $.device.phoneNumber       | /components/schemas/PhoneNumber             |
-            | $.device.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
-            | $.device.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | $.device.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | device_identifier                  | oas_spec_schema                             |
+            | {path_to_device}.phoneNumber       | /components/schemas/PhoneNumber             |
+            | {path_to_device}.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
+            | {path_to_device}.ipv6Address       | /components/schemas/DeviceIpv6Address       |
+            | {path_to_device}.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-    @{{feature_identifier}}_C01.03_device_not_found
+    @{feature_identifier}_C01.03_device_not_found
     Scenario: Some identifier cannot be matched to a device
         Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "$.device" is compliant with the schema but does not identify a valid device
+        And the request body property "{path_to_device}" is compliant with the schema but does not identify a valid device
         When the request "{operationId}" is sent
         Then the response status code is 404
         And the response property "$.status" is 404
         And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
-    @{{feature_identifier}}_C01.04_unnecessary_device
+    @{feature_identifier}_C01.04_unnecessary_device
     Scenario: Device not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a device
-        And the request body property "$.device" is set to a valid device
+        And the request body property "{path_to_device}" is set to a valid device
         When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
         And the response property "$.message" contains a user-friendly text
 
-    @{{feature_identifier}}_C01.05_missing_device
+    @{feature_identifier}_C01.05_missing_device
     Scenario: Device not included and cannot be deduced from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "$.device" is not included
+        And the request body property "{path_to_device}" is not included
         When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "MISSING_IDENTIFIER"
         And the response property "$.message" contains a user-friendly text
 
-    @{{feature_identifier}}_C01.06_unsupported_device
+    @{feature_identifier}_C01.06_unsupported_device
     Scenario: None of the provided device identifiers is supported by the implementation
         Given that some types of device identifiers are not supported by the implementation
         And the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "$.device" only includes device identifiers not supported by the implementation
+        And the request body property "{path_to_device}" only includes device identifiers not supported by the implementation
         When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
@@ -88,7 +93,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
         And the response property "$.message" contains a user-friendly text
 
     # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-    @{{feature_identifier}}_C01.07_device_not_supported
+    @{feature_identifier}_C01.07_device_not_supported
     Scenario: Service not available for the device
         Given that the service is not available for all devices commercialized by the operator
         And a valid device, identified by the token or provided in the request body, for which the service is not applicable

--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -2,7 +2,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
     CAMARA Commonalities: 0.6
     
-    Common error scenarios for POST operations with device as input either in the request
+    Common error scenarios for operations with device as input either in the request
     body or implied from the access.
 
     NOTES:
@@ -22,7 +22,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario: The device value is an empty object
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is set to: {}
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 400
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
@@ -32,7 +32,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario Outline: Some device identifier value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 400
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
@@ -50,7 +50,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario: Some identifier cannot be matched to a device
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is compliant with the schema but does not identify a valid device
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 404
         And the response property "$.status" is 404
         And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
@@ -60,7 +60,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario: Device not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a device
         And the request body property "$.device" is set to a valid device
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
@@ -70,7 +70,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario: Device not included and cannot be deduced from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" is not included
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "MISSING_IDENTIFIER"
@@ -81,7 +81,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
         Given that some types of device identifiers are not supported by the implementation
         And the header "Authorization" is set to a valid access token which does not identify a single device
         And the request body property "$.device" only includes device identifiers not supported by the implementation
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
@@ -92,7 +92,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     Scenario: Service not available for the device
         Given that the service is not available for all devices commercialized by the operator
         And a valid device, identified by the token or provided in the request body, for which the service is not applicable
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "SERVICE_NOT_APPLICABLE"

--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -1,5 +1,7 @@
 Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
+    CAMARA Commonalities: 0.6
+    
     Common error scenarios for POST operations with device as input either in the request
     body or implied from the access.
 
@@ -95,16 +97,3 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
         And the response property "$.status" is 422
         And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user-friendly text
-
-    # Several identifiers provided but they do not identify the same device
-    # This scenario may happen with 2-legged access tokens, which do not identify a device
-    @{{feature_identifier}}_C01.08_device_identifiers_mismatch
-    Scenario: Device identifiers mismatch
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And at least 2 types of device identifiers are supported by the implementation
-        And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "IDENTIFIER_MISMATCH"
-        And the response property "$.message" contains a user friendly text

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -62,3 +62,14 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
         And the response property "$.status" is 422
         And the response property "$.code" is "MISSING_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
+
+    # When the service is only offered to certain type of subscriptions, e.g. IoT, , B2C, etc
+    @{feature_identifier}_C02.05_phone_number_not_supported
+    Scenario: Service not available for the phone number
+        Given that the service is not available for all phone numbers commercialized by the operator
+        And a valid phone number, identified by the token or provided in the request body, for which the service is not applicable
+        When the request "{operationId}" is sent
+        Then the response status code is 422
+        And the response property "$.status" is 422
+        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+        And the response property "$.message" contains a user friendly text

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -2,7 +2,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
 
     CAMARA Commonalities: 0.6
 
-    Common error scenarios for POST operations with phoneNumber as input either in the request
+    Common error scenarios for operations with phoneNumber as input either in the request
     body or implied from the access
 
     NOTES:
@@ -22,7 +22,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     Scenario: Phone number value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
         And the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 400
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
@@ -32,7 +32,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     Scenario: Phone number not found
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
         And the request body property "$.phoneNumber" is compliant with the schema but does not identify a valid phone number
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 404
         And the response property "$.status" is 404
         And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
@@ -42,7 +42,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     Scenario: Phone number not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a phone number
         And  the request body property "$.phoneNumber" is set to a valid phone number
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
@@ -52,7 +52,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     Scenario: Phone number not included and cannot be deducted from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
         And the request body property "$.phoneNumber" is not included
-        When the HTTP "POST" request is sent
+        When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "MISSING_IDENTIFIER"

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -1,5 +1,7 @@
 Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
 
+    CAMARA Commonalities: 0.6
+
     Common error scenarios for POST operations with phoneNumber as input either in the request
     body or implied from the access
 
@@ -54,15 +56,4 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "MISSING_IDENTIFIER"
-        And the response property "$.message" contains a user friendly text
-
-    # When the service is only offered to certain type of subscriptions, e.g. IoT, , B2C, etc
-    @{{feature_identifier}}_C02.05_phone_number_not_supported
-    Scenario: Service not available for the phone number
-        Given that the service is not available for all phone numbers commercialized by the operator
-        And a valid phone number, identified by the token or provided in the request body, for which the service is not applicable
-        When the HTTP "POST" request is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
         And the response property "$.message" contains a user friendly text

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -13,45 +13,50 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     * These scenarios assume that other properties not explicitly mentioned in the scenario
       are set by default to a valid value. This can be specified in the feature Background.
 
-    * {{feature_identifier}} has to be substituted to the value corresponding to the feature file where
+    * {feature_identifier} has to be substituted to the value corresponding to the feature file where
     these scenarios are included.
+
+    * {operationId} has to be substituted to the value of operationId for the tested operation
+
+    * {path_to_phoneNumber} has to be substituted to the JSON path of the phoneNumber property in the body request, typically 
+    "$.phoneNumber" or "$.config.subscriptionDetail.phoneNumber" for Subscription APIs
 
     # Error scenarios for management of input parameter phoneNumber
 
-    @{{feature_identifier}}_C02.01_phone_number_not_schema_compliant
+    @{feature_identifier}_C02.01_phone_number_not_schema_compliant
     Scenario: Phone number value does not comply with the schema
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "$.phoneNumber" does not comply with the OAS schema at "/components/schemas/PhoneNumber"
+        And the request body property "{path_to_phoneNumber}" does not comply with the OAS schema at "/components/schemas/PhoneNumber"
         When the request "{operationId}" is sent
         Then the response status code is 400
         And the response property "$.status" is 400
         And the response property "$.code" is "INVALID_ARGUMENT"
         And the response property "$.message" contains a user friendly text
 
-    @{{feature_identifier}}_C02.02_phone_number_not_found
+    @{feature_identifier}_C02.02_phone_number_not_found
     Scenario: Phone number not found
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "$.phoneNumber" is compliant with the schema but does not identify a valid phone number
+        And the request body property "{path_to_phoneNumber}" is compliant with the schema but does not identify a valid phone number
         When the request "{operationId}" is sent
         Then the response status code is 404
         And the response property "$.status" is 404
         And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
         And the response property "$.message" contains a user friendly text
 
-    @{{feature_identifier}}_C02.03_unnecessary_phone_number
+    @{feature_identifier}_C02.03_unnecessary_phone_number
     Scenario: Phone number not to be included when it can be deduced from the access token
         Given the header "Authorization" is set to a valid access token identifying a phone number
-        And  the request body property "$.phoneNumber" is set to a valid phone number
+        And  the request body property "{path_to_phoneNumber}" is set to a valid phone number
         When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422
         And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
         And the response property "$.message" contains a user friendly text
 
-    @{{feature_identifier}}_C02.04_missing_phone_number
+    @{feature_identifier}_C02.04_missing_phone_number
     Scenario: Phone number not included and cannot be deducted from the access token
         Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "$.phoneNumber" is not included
+        And the request body property "{path_to_phoneNumber}" is not included
         When the request "{operationId}" is sent
         Then the response status code is 422
         And the response property "$.status" is 422


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

Error 422 IDENTIFIER_MISMATCH has been deprecated from 
  

#### Which issue(s) this PR fixes:

Fixes #476 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

It can be discussed. Previously, clients got an error for the mismatch and now the service may be applied for one of the provided identifiers

#### Special notes for reviewers:

I have added a line indicating the Commonalities version that the artifact is aligned with. This makes easier to see if an artifact has been updated after certain version of Commonalities.

I have not included alternative scenarios as guidelines do not dictate an specific behaviour for cases where there is a mismatch. Only that an error indicating so must not be returned. Implementations may consider any of the provided identifiers and response may be 2xx or even another error, like 404

#### Changelog input

```
* Removed scenarios testing 422 IDENTIFIER_MISMATCH

```

