### PR TITLE
Missing bullet point for Mandatory Errors restored  in CAMARA API Design Guide

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -319,6 +319,7 @@ In the following, we elaborate on the existing client errors. In particular, we 
 
 - For event subscriptions APIs, the ones defined in Event Subscription section of [CAMARA API Event Subscription and Notification Guide](/documentation/CAMARA-API-Event-Subscription-and-Notification.md)
 - For event notifications flow, the ones defined in Event Notification section of [CAMARA API Event Subscription and Notification Guide](/documentation/CAMARA-API-Event-Subscription-and-Notification.md)
+- For the rest of APIs: 
   - Error status 401
   - Error status 403
 


### PR DESCRIPTION


#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Missing bullet point is restored in the list of Mandatory Errors to be documented in CAMARA API Spec YAML  in  CAMARA-API-Design-Guide.md 
The bullet point indicating mandatory errors  for non-subscription APIs was present in v0.5.0, but was removed unintentionally with the creation of CAMARA API Design Guide.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:

Hot-fix to avoid confusion related to mandatory errors:

-  Error status 401
-  Error status 403


#### Changelog input

```
Missing bullet point for Mandatory Errors restored  in CAMARA API Design Guide

```
