### PR TITLE
Fall 25 Feature Files to provide schema context

### DIFF
--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -21,6 +21,10 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
     * {path_to_device} has to be substituted to the JSON path of the device property in the body request, typically 
     "$.device" or "$.config.subscriptionDetail.device" for Subscription APIs
 
+  # This feature file is to be used by CAMARA subproject when Common error scenarios for operations with device as input either in the request body or implied from the access.
+  #
+  # References to OAS spec schemas refer to schemas specified in {apiname}.yaml
+
     # Error scenarios for management of input parameter device
 
     @{feature_identifier}_C01.01_device_empty

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -21,6 +21,10 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
     * {path_to_phoneNumber} has to be substituted to the JSON path of the phoneNumber property in the body request, typically 
     "$.phoneNumber" or "$.config.subscriptionDetail.phoneNumber" for Subscription APIs
 
+  # This feature file is to be used by CAMARA subproject when Common error scenarios for operations with phoneNumber as input either in the request body or implied from the access
+  #
+  # References to OAS spec schemas refer to schemas specified in {apiname}.yaml
+
     # Error scenarios for management of input parameter phoneNumber
 
     @{feature_identifier}_C02.01_phone_number_not_schema_compliant

--- a/documentation/API-Testing-Guidelines.md
+++ b/documentation/API-Testing-Guidelines.md
@@ -129,7 +129,9 @@ Feature: CAMARA Device location verification API, v0.2.0 - Operation verifyLocat
 
 #### Feature Context
 
-Every feature will include a context after the `Feature` tag to provide relevant information about the implementation and execution of the tests.
+Every feature may include a context after the `Feature` tag to provide relevant information about the implementation and execution of the tests.
+
+This feature context is RECOMMENDED unless it does not provide additional value (e.g. all the info could have been given in the Background section for a certain API)
 
 For the feature context, the following template should be used:
 
@@ -142,7 +144,25 @@ For the feature context, the following template should be used:
   # Testing assets:
   # * 
   #
-  # References to OAS spec schemas refer to schemas specifies in {apiname}.yaml, version {version}
+  # References to OAS spec schemas refer to schemas specifies in {apiname}.yaml
+```
+
+An example for this feature context is depicted below:
+
+```
+    # Input to be provided by the implementation to the tester
+    #
+    # Implementation indications:
+    # * apiRoot: API root of the server URL
+    # * List of device identifier types which are not supported, among: phoneNumber, ipv4Address, ipv6Address.
+    #   For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
+    # * List of application server IP formats which are not supported, among ipv4 and ipv6.
+    #
+    # Testing assets:
+    # * A device object applicable for Quality On Demand service.
+    # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any.
+    #
+    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml
 ```
 
 ### Environment variables

--- a/documentation/API-Testing-Guidelines.md
+++ b/documentation/API-Testing-Guidelines.md
@@ -127,6 +127,24 @@ For the Feature description, API name and version must be included. When the fea
 Feature: CAMARA Device location verification API, v0.2.0 - Operation verifyLocation
 ```
 
+#### Feature Context
+
+Every feature will include a context after the `Feature` tag to provide relevant information about the implementation and execution of the tests.
+
+For the feature context, the following template should be used:
+
+```
+  # Input to be provided by the implementation to the tester
+  #
+  # Implementation indications:
+  # * 
+  #
+  # Testing assets:
+  # * 
+  #
+  # References to OAS spec schemas refer to schemas specifies in {apiname}.yaml, version {version}
+```
+
 ### Environment variables
 
 Commonly, some values to fill the request bodies will not be known in advance and cannot be specified as part of the feature file, as they will be specific for the test environment, and they will have to be provided by the implementation to the tester as a separate set of environment or configuration variables.

--- a/documentation/API-Testing-Guidelines.md
+++ b/documentation/API-Testing-Guidelines.md
@@ -144,7 +144,7 @@ For the feature context, the following template should be used:
   # Testing assets:
   # * 
   #
-  # References to OAS spec schemas refer to schemas specifies in {apiname}.yaml
+  # References to OAS spec schemas refer to schemas specified in {apiname}.yaml
 ```
 
 An example for this feature context is depicted below:
@@ -162,7 +162,7 @@ An example for this feature context is depicted below:
     # * A device object applicable for Quality On Demand service.
     # * A device object identifying a device commercialized by the implementation for which the service is not applicable, if any.
     #
-    # References to OAS spec schemas refer to schemas specifies in quality-on-demand.yaml
+    # References to OAS spec schemas refer to schemas specified in quality-on-demand.yaml
 ```
 
 ### Environment variables


### PR DESCRIPTION
#### What type of PR is this?

* enhancement
* documentation
* tests

#### What this PR does / why we need it:

This PR manages the topic raised in Issue #481, which indicates the lack of establising an schema context as indicated in PR #470 for event notification transversal gherkin template.

In this way, this PR proposes the following:
- Update [C01-device-errors.feature](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/C01-device-errors.feature) and [C02-phoneNumber-errors.feature](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/C02-phoneNumber-errors.feature) artifacts to provide such schema context and align with PR #470

- Update [API-Testing-Guidelines.md](https://github.com/camaraproject/Commonalities/blob/main/documentation/API-Testing-Guidelines.md) guide to document the `feature context` already being used across Feature files also referencing to the schema context


#### Which issue(s) this PR fixes:

Fixes #481 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:



#### Changelog input

```
 Setting a feature context

```

#### Additional documentation 

N/A