### PR TITLE
Fix Typo in Gherkin Device Errors Template

### DIFF
--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -52,7 +52,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
             | {path_to_device}.phoneNumber       | /components/schemas/PhoneNumber             |
             | {path_to_device}.ipv4Address       | /components/schemas/DeviceIpv4Addr          |
             | {path_to_device}.ipv6Address       | /components/schemas/DeviceIpv6Address       |
-            | {path_to_device}.networkIdentifier | /components/schemas/NetworkAccessIdentifier |
+            | {path_to_device}.networkAccessIdentifier | /components/schemas/NetworkAccessIdentifier |
 
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
     @{feature_identifier}_C01.03_device_not_found


### PR DESCRIPTION
#### What type of PR is this?

* bug
* correction


#### What this PR does / why we need it:

Fix [typo](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/C01-device-errors.feature#L55) in [C01-device-errors.feature](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/C01-device-errors.feature). It should read: `{path_to_device}.networkAccessIdentifier`


#### Which issue(s) this PR fixes:

Fixes #522 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


#### Special notes for reviewers:

N/A

#### Changelog input

```
 Fix Typo in Gherkin Device Errors Template

```

#### Additional documentation 

N/A

