### PR TITLE
fix: change networkAccessIdentifier and notification server example to use `example.com` 

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -100,7 +100,7 @@ components:
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
       type: string
-      example: "123456789@domain.com"
+      example: "123456789@example.com"
 
     DeviceIpv4Addr:
       type: object
@@ -795,3 +795,4 @@ components:
                 status: 504
                 code: TIMEOUT
                 message: Request timeout exceeded.
+

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -609,7 +609,7 @@ components:
         - Application-specific identifier:
           * /cloudevents/spec/pull/123
           * 1-555-123-4567
-      example: "https://notificationSendServer12.supertelco.com"
+      example: "https://notificationSendServer12.example.com"
 
     DateTime:
       type: string

--- a/artifacts/notification-as-cloud-event.yaml
+++ b/artifacts/notification-as-cloud-event.yaml
@@ -153,7 +153,7 @@ components:
         - Application-specific identifier:
           * /cloudevents/spec/pull/123
           * 1-555-123-4567
-      example: "https://notificationSendServer12.supertelco.com"
+      example: "https://notificationSendServer12.example.com"
 
     CloudEvent:
       description: The notification callback
@@ -333,7 +333,7 @@ components:
     QOS_STATUS_CHANGED_EXAMPLE:
       value:
         id: "123e4567-e89b-12d3-a456-426655440000"
-        source: "https://notificationSendServer12.supertelco.com"
+        source: "https://notificationSendServer12.example.com"
         type: "org.camaraproject.quality-on-demand.v0.qos-status-changed"
         specversion: "1.0"
         time: "2023-01-17T13:18:23.682Z"

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -508,7 +508,7 @@ curl -X 'POST' \
  ```json
 {
   "id": 123654,
-  "source": "https://notificationSendServer12.supertelco.com",
+  "source": "https://notificationSendServer12.example.com",
   "type": "org.camaraproject.device-roaming-subscriptions.v1.roaming-status",
   "specversion": "1.0",
   "datacontenttype": "application/json",
@@ -545,7 +545,7 @@ curl -X 'POST' \
  ```json
 {
   "id": 123658,
-  "source": "https://notificationSendServer12.supertelco.com",
+  "source": "https://notificationSendServer12.example.com",
   "type": "org.camaraproject.api.device-roaming-subscriptions.v1.subscription-ended",
   "specversion": "1.0",
   "datacontenttype": "application/json",


### PR DESCRIPTION
#### What type of PR is this?

<!-- Add one of the following kinds: -->

* correction

#### What this PR does / why we need it:

Changes the example in the `networkAccessIdentifier`  schema from `domain.com` (a live commercial web address) to `example.com` (as reserved in RFC 2606 for such examples).


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #529 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
