### PR TITLE
Fix for link and description of `SubscriptionId` in  event-subscription-template.yaml

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -552,7 +552,7 @@ components:
 
     SubscriptionId:
       type: string
-      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, this concept SHALL be referred as `subscriptionId` as per [Commonalities Event Notification Model](/documentation/API-design-guidelines.md#122-event-notification).
+      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, it SHALL be referred to as `subscriptionId` as per the Commonalities Event Notification Model.
       example: qs15-h556-rt89-1298
 
     CloudEvent:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:
Link was referencing  deprecated API Design Guidelines document.
Link was removed and description was grammatically corrected


#### Which issue(s) this PR fixes:
Fixes #531 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



#### Special notes for reviewers:



#### Changelog input

```
Description of `SubscriptionId` in  event-subscription-template.yaml was fixed - link removed

```

