### PR TITLE
Fix x-camara-commonalities format

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -6,7 +6,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: "wip"
   
 paths: {}
 components:

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -13,7 +13,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: "wip"
   
 externalDocs:
   description: Product documentation at CAMARA

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -626,7 +626,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   # CAMARA Commonalities minor version - x.y
-  x-camara-commonalities: 0.5
+  x-camara-commonalities: "0.5"
 ```
 
 #### 5.3.1. Title


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

This PR fixes  `x-camara-commonalities` format to be interpreted as a string and not an integer as it considers for its versioning major an minor versions.

NOTE: The value is settled to "wip" as being part of the new Spring26 MetaRelease cycle


#### Which issue(s) this PR fixes:

Fixes #528 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:



#### Changelog input

```
 Fix x-camara-commonalities format as a string

```

#### Additional documentation 

This section can be blank.



```
docs

```
