### PR TITLE
Success Responses with Meta Information

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -851,7 +851,8 @@ CAMARA APIs MAY include an optional `meta` field in success responses to express
 ```yaml
 components:
   schemas:
-    ExampleResponse:
+    ExampleSuccessResponseWithMeta:
+
       type: object
       # Conditional requirement:
       #   - Either `meta` MUST be present alone, OR


### PR DESCRIPTION
#### What type of PR is this?

<!-- Add one of the following kinds: -->
* enhancement/feature


#### What this PR does / why we need it:

Current CAMARA API Design Guide does not define option to define handling for 'limited' success responses for valid requests with partial fulfillment.   In addition, while the `ErrorInfo` structure allows for 4xx/5xx responses to provide insights, there is no option to provide such insights for the 2xx, success responses.  This PR introduces a new subsection in the Design Guide referencing the [JSON API: Meta Information](https://jsonapi.org/format/#document-meta) for a conditional optional property to be considered by the API Designers for sharing `meta` data, either for supplementary purposes or to handle partial cases, such as indeterminate situations.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #555 



#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- Conditional Optional Meta Information Property definition in API Designs
```

#### Additional documentation 

Obsoletes #557


```
docs

```
