### PR TITLE
CAMARA_Common.yaml aligment with multiple device identifiers logic

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -67,7 +67,7 @@ components:
             * `ipv6Address`
             * `phoneNumber`
             * `networkAccessIdentifier`
-            NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the API Provider will consider one of them for the API logic, without performing any matching checking among the provided identifiers.
+            NOTE1: the network operator might support only a subset of these options. The API Consumer can provide multiple identifiers to ensure compatibility across different network operators. In this case, the API Provider will use one of the identifiers for the API logic without performing any matching checks among the provided identifiers.
             NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
       properties:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

In MetaRelease Fall25, IDENTIFIER_MISMATCH exception is removed. In other words, when an API Client indicates more than one identifier for a device, API provider will take one of them for the API logic, without performing any matching checking among identifiers provided by API client.

Reference:
https://github.com/camaraproject/Commonalities/issues/431

In CAMARA_Common.yaml it is reflected for [device object](https://github.com/camaraproject/Commonalities/blob/main/artifacts/CAMARA_common.yaml#L70):

NOTE1: the network operator might support only a subset of these options. The API invoker can provide multiple identifiers to be compatible across different network operators. In this case the identifiers MUST belong to the same device.

And this is misleading, because now the API logic does not perform any matching among them so as it is not an issue nor a requirement that they MUST belong to the same device.


#### Which issue(s) this PR fixes:

Fixes #566 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:



#### Changelog input

```
 CAMARA_Common.yaml aligment with multiple device identifiers logic

```

#### Additional documentation 

This section can be blank.



```
docs

```
