### PR TITLE
Clarifications for asynchronous responses

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -833,7 +833,7 @@ responses:
     $ref: "#/components/responses/<schema-name>"
 ```
 
-##### 5.7.6.2 Asynchronous responses
+##### 5.7.6.1 Asynchronous responses
 
 An asynchronous response is not truly an event. An event is something that may occur once or multiple times, and it is the occurrence of that event that carries the main information. In contrast, an asynchronous response represents meta-information delivered in the same format as a synchronous response and happens exactly once.
 


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature
* documentation

#### What this PR does / why we need it:

This PR address some guidelines with regards to scenarios where API response is provided asynchronously. It is stated that the response model does NOT have to follow CAMARA cloudevents-based event notification model as the conclusion from Issue #533.


#### Which issue(s) this PR fixes:

Fixes #533 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


#### Special notes for reviewers:



#### Changelog input

```
 Clarifications for asynchronous responses

```

#### Additional documentation 

This section can be blank.



```
docs

```
