### PR TITLE
docs: add device identifier constraints per #513

### DIFF
--- a/documentation/API-Testing-Guidelines.md
+++ b/documentation/API-Testing-Guidelines.md
@@ -339,7 +339,7 @@ _Mandatory for any API using 2-legged access tokens_
 ```
 And the response property "$.device" contains a single device identifier that was included in the request
 ```
-Note, the inclusion of "$.device" in the request body should be an exisintg constraint for when 2-legged
+Note, the inclusion of "$.device" in the request body SHOULD be an existing constraint for when 2-legged
 access tokens are used.
 
 


### PR DESCRIPTION
Added guidelines for the inclusion of the `$.device` property in API responses based on request conditions, specifying scenarios for both API provider discretion and mandatory inclusion for 2-legged access tokens.

#### What type of PR is this?

<!-- Add one of the following kinds: -->
* documentation

#### What this PR does / why we need it:

Clarifies the `.feature` constraints that should be used where the `$.device` object has been included in the request body.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #513 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
