### PR TITLE
Correction in table in section 3.1 of API Design Guide

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -1281,6 +1281,3 @@ This approach simplifies API usage for API consumers using a three-legged access
 
 - If the subject can be identified from the access token and the optional [`device` object | `phoneNumber` field](*) is also included in the request, then the server will return an error with the `422 UNNECESSARY_IDENTIFIER` error code. This will be the case even if the same [ device | phone number ](*) is identified by these two methods, as the server is unable to make this comparison.
 ```
-
-
-


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

After merging https://github.com/camaraproject/Commonalities/pull/569 the table in section [3.1](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#31-standardized-use-of-camara-error-responses) was not rendering correctly.

#### Which issue(s) this PR fixes:

Fixes #562 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
Table in section 3.1 of API Design Guide corrected

```

#### Additional documentation 

