### PR TITLE
Event subscription template  - alignment with OWASP and other linting rules

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -647,7 +647,6 @@ components:
 
     InitiationReason:
       type: string
-      maxLength: 512
       description: |
         - SUBSCRIPTION_CREATED - Subscription created by API Server
       enum:
@@ -680,7 +679,6 @@ components:
 
     UpdateReason:
       type: string
-      maxLength: 512
       description: |
         - SUBSCRIPTION_ACTIVE - API server transitioned susbcription status to `ACTIVE`
         - SUBSCRIPTION_INACTIVE - API server transitioned susbcription status to `INACTIVE`
@@ -715,7 +713,6 @@ components:
 
     TerminationReason:
       type: string
-      maxLength: 512
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
         - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:

CAMARA_common.yaml includes schema definitions that raise linter errors when used in CAMARA API specifications.
New OWASP API linting rules will raise additional erros related to unrestricted string/integer properties.
This PR:

- Event subscription template  with limits/restrictions for string/integer properties (in line with proposed in #590)
- Adds missing descriptions and type
- adjust formatting for YAML syntax


#### Which issue(s) this PR fixes:

Fixes #585 


#### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:

What is reasonable value for maximal number of subscriptions returned to API consumer for` GET /subscriptions` ?
Should we think about pagination?

The values for not used transports (like MQTT, Kafka) can be refined when we decide to implement them.
For now some values are proposed, so the template file conforms to linting rules.

#### Changelog input

```
Event subscription template  - aligned with OWASP and other linting rules

```

#### Additional documentation 

https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md#5-owasp-api-security-top-10-2023-rules

