### PR TITLE
Add optional GeoJSON geometry schema and design guidance to Commonalities

### DIFF
--- a/documentation/geojson-guidance.md
+++ b/documentation/geojson-guidance.md
@@ -1,0 +1,118 @@
+# GeoJSON Geometry Model (Optional) – Commonalities Guidance
+
+This document introduces an **optional GeoJSON (RFC 7946)** geometry model for CAMARA APIs that require spatial comparison or GIS-native capabilities.
+
+The intention is **not** to replace the existing CAMARA `Area` datatype, but to provide an additional model when needed, 
+without impacting existing and future CAMARA APIs that only require simple Circle or Polygon structures.
+
+---
+
+## 1. Motivation
+
+Some CAMARA APIs currently perform **geometric comparisons**, such as:
+
+- checking containment (within)
+- checking intersection / overlap
+- computing an intersection area
+- determining coverage relationships
+
+These are best handled using **GIS-native geometry models**, which already exist in spatial databases and GIS engines.
+
+The current CAMARA `Area` model (Circle / Polygon using custom JSON) is sufficient for *simple* APIs that only **return** an area.  
+However, APIs performing **spatial predicates** benefit from using a standard format.
+
+---
+
+## 2. Proposal
+
+Introduce an **optional** geometry type:
+```json
+GeoJSONGeometry:
+type: object
+description: RFC 7946 GeoJSON geometry object
+```
+
+---
+
+APIs MAY choose whether to use:
+
+- **CAMARA `Area` (Circle/Polygon)** → for simple location-returning APIs  
+- **`GeoJSONGeometry`** → for APIs requiring spatial search, geometric comparisons, or integration with GIS engines
+
+This proposal:
+- does **not** require any existing API to change  
+- does **not** mandate a `oneOf` with both models  
+- keeps Area/Circle/Polygon fully valid
+- lets each API initiative decide independently which model is appropriate.
+
+---
+## 3. Why Optional GeoJSON?
+
+### 3.1 CAMARA principles
+CAMARA aims to provide **simple, developer-friendly APIs**.  
+Many APIs do not need full GIS capability, and forcing GeoJSON adoption would add
+unnecessary complexity.
+
+### 3.2 When to use CAMARA Area
+Use the existing `Area` / `Circle` / `Polygon` types when an API only needs to:
+
+- return a device location area  
+- represent coarse-grained coverage  
+- pass a simple geometric boundary without geometric computations  
+
+### 3.3 When GeoJSON helps
+Use GeoJSON when an API must perform:
+
+- overlap detection
+- containment verification
+- geometric search among multiple areas
+- distance or coverage evaluation
+- spatial indexing through GIS engines
+
+GeoJSON aligns with existing mature stacks such as PostGIS, Oracle Spatial,
+SQL Server Geography, GeoServer, Elasticsearch, MongoDB, and others.
+
+---
+
+## 4. Circles in GeoJSON
+
+GeoJSON does not define a `Circle` type, consistent with GIS industry practice.
+Common approaches include:
+
+- **Polygon approximation** (recommended and universally supported)
+- **Feature(Point) + radius** as a convenience input extension
+- Optional `"type": "Circle"` as a non-standard hint, internally converted to polygon
+
+All approaches result in a Polygon for authoritative spatial operations.
+
+---
+
+## 5. API Design Guidance
+
+To avoid fragmentation and keep APIs simple, the following guidance is recommended:
+
+- **Simple APIs**  
+  (that only *return* an area)  
+  → SHOULD use the existing CAMARA `Area` datatype.
+
+- **APIs requiring geometric comparison**  
+  (containment, overlap, match rate, coverage, spatial search)  
+  → SHOULD consider using the optional `GeoJSONGeometry` datatype.
+
+- **Each API initiative remains autonomous**  
+  No API is required to support both models.  
+  API designers choose the most suitable model for their scenario.
+
+---
+
+## 6. Summary
+
+This proposal provides:
+
+- a **non-breaking**, optional extension  
+- better support for APIs with spatial logic  
+- reuse of GIS-native capabilities  
+- continued simplicity for basic APIs  
+- a unified geometry model across CAMARA when spatial search is needed
+
+No changes are required in existing API definitions unless they choose to adopt GeoJSON.

--- a/documentation/geojson-guidance.md
+++ b/documentation/geojson-guidance.md
@@ -1,6 +1,6 @@
 # GeoJSON Geometry Model (Optional) – Commonalities Guidance
 
-This document introduces an **optional GeoJSON (RFC 7946)** geometry model for CAMARA APIs that require spatial comparison or GIS-native capabilities.
+This document introduces an **optional [GeoJSON (RFC 7946)](https://www.rfc-editor.org/rfc/rfc7946.html)** geometry model for CAMARA APIs that require spatial comparison or GIS-native capabilities.
 
 The intention is **not** to replace the existing CAMARA `Area` datatype, but to provide an additional model when needed, 
 without impacting existing and future CAMARA APIs that only require simple Circle or Polygon structures.

--- a/documentation/geojson-guidance.md
+++ b/documentation/geojson-guidance.md
@@ -18,7 +18,7 @@ Some CAMARA APIs currently perform **geometric comparisons**, such as:
 
 These are best handled using **GIS-native geometry models**, which already exist in spatial databases and GIS engines.
 
-The current CAMARA `Area` model (Circle / Polygon using custom JSON) is sufficient for *simple* APIs that only **return** an area.  
+The current CAMARA `Area` model (Circle / Polygon using custom JSON) is sufficient for *simple* APIs that only **return** an area and/or **require** an area as an input.  
 However, APIs performing **spatial predicates** benefit from using a standard format.
 
 ---


### PR DESCRIPTION
docs: add optional `GeoJSON` geometry guidance for CAMARA APIs

#### What type of PR is this?
* enhancement/feature
* documentation

#### What this PR does / why we need it:
This PR introduces **optional, non‑breaking support for `GeoJSON` (RFC 7946)** as an additional geometry model in Commonalities.

Several CAMARA APIs (e.g., Dedicated Network Service Areas, Device Location Verification) require **geometric comparison or spatial predicates** such as _within_, _overlaps_, _contains_, or _intersection area_. These operations are natively supported by spatial engines and databases **only when using standard geometry formats** such as **`GeoJSON`**.

This PR:
- adds **guidance documentation** on when to use the existing CAMARA `Area` datatype vs. when to consider **`GeoJSON`**;
- introduces a new optional **`GeoJSONGeometry`** schema for initiatives that need GIS‑native behavior;
- preserves the **CAMARA simplicity philosophy** by keeping the existing `Area`/`Circle`/`Polygon` model fully valid;
- does **not** require any API to adopt **`GeoJSON`**;
- does **not** impose a `oneOf` pattern or force dual‑model support;
- allows each API initiative to independently evaluate which geometry model is most appropriate.

This ensures that advanced spatial APIs can rely on GIS‑native capabilities, without adding complexity to APIs that only require simple geometries.

#### Which issue(s) this PR fixes:
#586 and fixes https://github.com/camaraproject/DedicatedNetworks/issues/93

#### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This PR only adds documentation and an optional GeoJSON schema. 
It does not change the existing Area/Circle/Polygon datatypes, nor require any API to adopt GeoJSON. The schema is made available for future initiatives that may benefit from it.

#### Special notes for reviewers:
- `GeoJSON` is proposed **as an optional alternative**, not as a required model.  
- The existing CAMARA `Area` model remains valid and unchanged.  
- No `oneOf` pattern is mandated.  
- This PR only provides **guidance + optional schema**, enabling GIS‑native behavior for APIs that require spatial predicates.  
- Adds no operational complexity to APIs that simply return a device area.  

Feedback on naming, wording of the guidance, and **file placement** (e.g., `docs/geojson-guidance.md` and, if included, `code/API_definitions/geojson.yaml`) is welcome.

#### Changelog input
```
release-note
Add optional GeoJSONGeometry schema and guidance for APIs requiring spatial predicates; no changes to existing CAMARA Area model.
```
#### Additional documentation:
documentation/geojson-guidance.md