### PR TITLE
Relaxing NAI length restriction from 253 to 2048

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -114,7 +114,7 @@ components:
     NetworkAccessIdentifier:
       description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
       type: string
-      maxLength: 253
+      maxLength: 2048
       example: "123456789@example.com"
 
     DeviceIpv4Address:


### PR DESCRIPTION
#### What type of PR is this?

<!-- Add one of the following kinds: -->
* correction

#### What this PR does / why we need it:

The PR relaxes the NAI length restriction from 253 to 2048, avoid unnecessary length restrictions.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes https://github.com/camaraproject/Commonalities/issues/593

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
Relaxing the NAI length restriction from 253 to 2048, avoid unnecessary length restrictions.

```

#### Additional documentation 

This section can be blank.



```
docs

```
