### PR TITLE
fix: x-camara-commonalities to use full version string

### DIFF
--- a/artifacts/CAMARA_common.yaml
+++ b/artifacts/CAMARA_common.yaml
@@ -7,7 +7,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.8.0-rc.1
 
-  x-camara-commonalities: "0.7"
+  x-camara-commonalities: 0.7.0
 
 paths: {}
 components:

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -13,7 +13,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.4.0-rc.1
-  x-camara-commonalities: "0.7"
+  x-camara-commonalities: 0.7.0
   
 externalDocs:
   description: Product documentation at CAMARA

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -764,8 +764,8 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  # CAMARA Commonalities minor version - x.y
-  x-camara-commonalities: "0.6"
+  # CAMARA Commonalities version
+  x-camara-commonalities: 0.7.0
 ```
 
 #### 5.3.1. Title
@@ -801,7 +801,7 @@ license
 ```
 
 #### 5.3.7. Extension Field
-The API SHALL specify the Commonalities minor release number they are compliant to, by including the `x-camara-commonalities` extension field.
+The API SHALL specify the Commonalities release version they are compliant to, by including the `x-camara-commonalities` extension field. The value is the full version string of the Commonalities release used by the API, as stored in `VERSION.yaml` at the corresponding Commonalities release tag (e.g. `0.7.0` for a public release, or `0.7.0-rc.1` for a pre-release).
 
 ### 5.4. ExternalDocs Object
 The `externalDocs` object SHALL have the following content:


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Updates the `x-camara-commonalities` extension field to use the full version string (e.g. `0.7.0` or `0.7.0-rc.1`) instead of just the minor version (e.g. `"0.7"`).

With the introduction of release automation ([tooling#119](https://github.com/camaraproject/tooling/pull/119)), this field is set automatically using the version from `VERSION.yaml` at the Commonalities release tag. The original restriction to minor-only was motivated by manual maintenance effort, which no longer applies.

Changes:
- **API Design Guide** (section 5.3.7): updated guideline text and example to use full version string
- **CAMARA_common.yaml**: `"0.7"` → `0.7.0`
- **event-subscription-template.yaml**: `"0.7"` → `0.7.0`

#### Which issue(s) this PR fixes:

Fixes #598

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

The release automation tooling already writes the full version string. This PR aligns the guideline and artifacts with the automated behavior.

#### Changelog input

```
 release-note
x-camara-commonalities extension field now uses full version string (e.g. 0.7.0) instead of minor-only (e.g. 0.7)
```

#### Additional documentation

```
docs
Updated section 5.3.7 of CAMARA-API-Design-Guide.md
```