### PR TITLE
Cloudevents decoupled from EventTypeNotification scheme in Event Subscription Template

### DIFF
--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -21,7 +21,7 @@ externalDocs:
   # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
 servers:
   - url: "{apiRoot}/api-name/vx.y"
-    # api-name and version should be valued accordingly to the CAMARA API versioning guidelines, e.g. for a version x.y.z, put v0.y for x=0 or just vx for x>0 in the url.
+- url: "{apiRoot}/api-name/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091
@@ -442,7 +442,7 @@ components:
       type: string
       description: |
         Enum of API-specific event type strings for this API project.
-        The reverse-DNS prefix org.camaraproject.<api-name> makes each value
+        The reverse-DNS prefix `org.camaraproject.<api-name>` makes each value
         globally unique, so two different API groups can independently define
         identically-named event types without any collision risk.
       enum:
@@ -610,7 +610,7 @@ components:
           maxLength: 512
           description: |
             Identifies the event type. CAMARA APIs use reverse-DNS notation:
-            org.camaraproject.<api-name>.<event-version>.<event-name>
+            `org.camaraproject.<api-name>.<event-version>.<event-name>`
             The api-name segment makes each type globally unique across API groups.
         specversion:
           type: string
@@ -629,6 +629,8 @@ components:
           $ref: "#/components/schemas/DateTime"
 
     # ─────────────────────────────────────────────────────────────────────────
+    # API-specific notification event group
+    #
     # Extends CloudEvent via allOf and does exactly two things:
     #   1. Constrains `type` to its own ApiEventType enum
     #   2. Owns the discriminator mapping from each enum value to a concrete schema

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -13,7 +13,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: "0.7"
+  x-camara-commonalities: 0.7.0
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -221,10 +221,14 @@ components:
     openId:
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect authentication via discovery metadata.
     notificationsBearerAuth:
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
   parameters:
     SubscriptionId:
       name: subscriptionId
@@ -453,7 +457,6 @@ components:
     # and owns the lifecycle discriminator mapping.
     #
     # API projects reference this group via NotificationEvent but never modify it.
-    # In a split-file layout this schema lives in CAMARA_Events_common.yaml.
     # ─────────────────────────────────────────────────────────────────────────
 
     SubscriptionLifecycleEvent:
@@ -576,6 +579,12 @@ components:
       description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, it SHALL be referred to as `subscriptionId` as per the Commonalities Event Notification Model.
       example: qs15-h556-rt89-1298
 
+    # ─────────────────────────────────────────────────────────────────────────
+    # CloudEvents 1.0 envelope (Commonalities-owned, never modified)
+    #
+    # Knows nothing about CAMARA event types, data payloads, or discriminator
+    # mappings. Any CAMARA API that needs to send a notification starts here.
+    # ─────────────────────────────────────────────────────────────────────────
     CloudEvent:
       type: object
       description: |
@@ -598,6 +607,7 @@ components:
           $ref: "#/components/schemas/Source"
         type:
           type: string
+          maxLength: 512
           description: |
             Identifies the event type. CAMARA APIs use reverse-DNS notation:
             org.camaraproject.<api-name>.<event-version>.<event-name>
@@ -617,6 +627,7 @@ components:
           description: Event details payload. Structure is defined by each concrete event schema.
         time:
           $ref: "#/components/schemas/DateTime"
+
     # ─────────────────────────────────────────────────────────────────────────
     # Extends CloudEvent via allOf and does exactly two things:
     #   1. Constrains `type` to its own ApiEventType enum
@@ -644,7 +655,6 @@ components:
         mapping:
           org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
           org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
-
 
     Source:
       type: string
@@ -834,6 +844,7 @@ components:
     # ─────────────────────────────────────────────────────────────────────────
 
     HTTPSubscriptionRequest:
+      description: Subscription request for HTTP-based event delivery.
       allOf:
         - $ref: "#/components/schemas/SubscriptionRequest"
         - type: object
@@ -842,6 +853,7 @@ components:
               $ref: "#/components/schemas/HTTPSettings"
 
     HTTPSubscriptionResponse:
+      description: Subscription resource returned for HTTP-based event delivery.
       allOf:
         - $ref: "#/components/schemas/Subscription"
         - type: object
@@ -851,6 +863,7 @@ components:
 
     HTTPSettings:
       type: object
+      description: HTTP protocol settings for event delivery.
       properties:
         headers:
           type: object

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -67,7 +67,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/NotificationEvent"
               responses:
                 "204":
                   description: Successful notification
@@ -462,8 +462,6 @@ components:
         support explicit subscriptions.
         Extends the CloudEvent envelope and constrains `type` to the set of
         lifecycle event types managed by Commonalities.
-        API projects include this group via NotificationEvent.oneOf and must
-        not modify it.
       allOf:
         - $ref: "#/components/schemas/CloudEvent"
         - type: object
@@ -673,7 +671,7 @@ components:
       example: "2018-04-05T17:31:00Z"
 
     # ─────────────────────────────────────────────────────────────────────────
-    # Layer 2 — Callback union (API project-owned)
+    # Callback union (API project-owned)
     #
     # oneOf over all valid event groups at the callback endpoint.
     # Owns no discriminator and applies no constraints of its own.

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -5,6 +5,17 @@ info:
     This file is a template for CAMARA API explicit subscription endpoint and for Notification model.
     Additional information are provided in [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md).
 
+    ## Schema layering
+
+    | Schema | Owner | Responsibility |
+    |---|---|---|
+    | `CloudEvent` | Commonalities | CloudEvents 1.0 envelope — no CAMARA-specific constraints |
+    | `ApiNotificationEvent` | API project | Constrains `type` to `ApiEventType`; owns the discriminator mapping |
+    | `ApiEventType` | API project | Enum of valid API-specific event type strings |
+    | `SubscriptionLifecycleEvent` | Commonalities | Constrains `type` to `SubscriptionLifecycleEventType`; owns lifecycle discriminator |
+    | `SubscriptionLifecycleEventType` | Commonalities | Enum: subscription-started, subscription-updated, subscription-ended |
+    | `NotificationEvent` | API project | `oneOf` union at the callback endpoint — enumerates valid groups |
+
     Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<event-version>.<event-name>``
 
     Note on ``security`` - ``openId`` scope: The value in this yaml `api-name:event-type1:grant-level` must be replaced accordingly to the format defined in the guideline document.
@@ -12,20 +23,20 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.4.0-rc.1
+  version: wip
   x-camara-commonalities: "0.7"
-  
+
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/apiRepository
-  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
+
 servers:
   - url: "{apiRoot}/api-name/vx.y"
-    # api-name and version should be valued accordingly to the CAMARA API versioning guidelines, e.g. for a version x.y.z, put v0.y for x=0 or just vx for x>0 in the url.
     variables:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+
 tags:
   - name: <apiName> Subscription
     description: Operations to manage event subscriptions on event-type event
@@ -58,7 +69,7 @@ paths:
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
                 The apiName server will call this endpoint whenever a apiName event occurs.
-                `operationId` value will have to be replaced accordingly with WG API specific semantic
+                `operationId` value will have to be replaced accordingly with WG API specific semantic.
               operationId: postNotification
               parameters:
                 - $ref: "#/components/parameters/x-correlator"
@@ -67,7 +78,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/CloudEvent"
+                      $ref: "#/components/schemas/NotificationEvent"
               responses:
                 "204":
                   description: Successful notification
@@ -119,6 +130,7 @@ paths:
           $ref: "#/components/responses/CreateSubscriptionUnprocessableEntity422"
         "429":
           $ref: "#/components/responses/Generic429"
+
     get:
       tags:
         - <apiName> Subscription
@@ -150,6 +162,7 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
+
   /subscriptions/{subscriptionId}:
     get:
       tags:
@@ -181,6 +194,7 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
+
     delete:
       tags:
         - <apiName> Subscription
@@ -216,6 +230,7 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
+
 components:
   securitySchemes:
     openId:
@@ -225,6 +240,7 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+
   parameters:
     SubscriptionId:
       name: subscriptionId
@@ -239,15 +255,564 @@ components:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
+
   headers:
     x-correlator:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
+
   schemas:
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Layer 0 — CloudEvents 1.0 envelope (Commonalities-owned, never modified)
+    #
+    # Knows nothing about CAMARA event types, data payloads, or discriminator
+    # mappings. Any CAMARA API that needs to send a notification starts here.
+    # This schema MUST NOT be modified regardless of how many APIs or event
+    # types are added to the platform.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    CloudEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 specification envelope.
+        This schema is the stable base for all CAMARA event notifications.
+        It imposes no constraints on `type` values or `data` structure —
+        those concerns belong to the API-specific and lifecycle group schemas.
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - time
+      properties:
+        id:
+          type: string
+          maxLength: 256
+          description: Identifier of this event, unique within the source context.
+        source:
+          $ref: "#/components/schemas/Source"
+        specversion:
+          type: string
+          description: Version of the specification to which this event conforms.
+          enum:
+            - "1.0"
+        type:
+          type: string
+          description: |
+            Identifies the event type. CAMARA APIs use reverse-DNS notation:
+            org.camaraproject.<api-name>.<event-version>.<event-name>
+            The api-name segment makes each type globally unique across API groups.
+        datacontenttype:
+          type: string
+          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+          enum:
+            - application/json
+        data:
+          type: object
+          description: Event details payload. Structure is defined by each concrete event schema.
+        time:
+          $ref: "#/components/schemas/DateTime"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Layer 1a — API-specific event group (API project-owned)
+    #
+    # Extends CloudEvent via allOf and does exactly two things:
+    #   1. Constrains `type` to its own ApiEventType enum
+    #   2. Owns the discriminator mapping from each enum value to a concrete schema
+    #
+    # Adding a new event type requires only: adding a value to ApiEventType and
+    # adding a discriminator mapping entry here. CloudEvent is never touched.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    ApiNotificationEvent:
+      description: |
+        API-specific notification event group.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        event types defined by this API project.
+        Adding a new event type only requires updating ApiEventType and the
+        discriminator mapping below — the CloudEvent base never changes.
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/ApiEventType"
+      discriminator:
+        propertyName: type
+        mapping:
+          org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
+          org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
+
+    ApiEventType:
+      type: string
+      description: |
+        Enum of API-specific event type strings for this API project.
+        The reverse-DNS prefix org.camaraproject.<api-name> makes each value
+        globally unique, so two different API groups can independently define
+        identically-named event types without any collision risk.
+      enum:
+        - org.camaraproject.api-name.v0.event-type1
+        - org.camaraproject.api-name.v0.event-type2
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Layer 1b — Subscription lifecycle event group (Commonalities-owned)
+    #
+    # Common to every CAMARA API that supports subscriptions.
+    # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
+    # and owns the lifecycle discriminator mapping.
+    #
+    # API projects reference this group via NotificationEvent but never modify it.
+    # In a split-file layout this schema lives in CAMARA_Events_common.yaml.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionLifecycleEvent:
+      description: |
+        Subscription lifecycle event group, common to all CAMARA APIs that
+        support explicit subscriptions.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        lifecycle event types managed by Commonalities.
+        API projects include this group via NotificationEvent.oneOf and must
+        not modify it.
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/SubscriptionLifecycleEventType"
+      discriminator:
+        propertyName: type
+        mapping:
+          org.camaraproject.api-name.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
+          org.camaraproject.api-name.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
+          org.camaraproject.api-name.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
+
+    SubscriptionLifecycleEventType:
+      type: string
+      description: |
+        Enum of subscription lifecycle event type strings.
+        These are managed by Commonalities and are identical across all CAMARA
+        APIs that support explicit subscriptions.
+        Kept as a separate named schema so the set of valid lifecycle type
+        strings can be referenced independently from the discriminated schema.
+      enum:
+        - org.camaraproject.api-name.v0.subscription-started
+        - org.camaraproject.api-name.v0.subscription-updated
+        - org.camaraproject.api-name.v0.subscription-ended
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Layer 2 — Callback union (API project-owned)
+    #
+    # oneOf over all valid event groups at the callback endpoint.
+    # Owns no discriminator and applies no constraints of its own.
+    # Its only job is to enumerate which groups are valid for this API.
+    #
+    # To add a new event group: add it to the oneOf list. That is the only
+    # change required at this layer.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    NotificationEvent:
+      description: |
+        Union of all valid notification event groups at the callback endpoint.
+        This schema owns no discriminator — routing within each group is
+        handled by ApiNotificationEvent and SubscriptionLifecycleEvent
+        respectively. Its only responsibility is to enumerate which groups
+        are valid payloads for this API's notification callback.
+      oneOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — API-specific (API project-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventApiSpecific1:
+      description: Event structure for event-type1
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: |
+                Event-specific payload for event-type1.
+                Replace with the actual data schema for this event type.
+
+    EventApiSpecific2:
+      description: Event structure for event-type2
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: |
+                Event-specific payload for event-type2.
+                Replace with the actual data schema for this event type.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — Subscription lifecycle (Commonalities-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventSubscriptionStarted:
+      description: event structure for subscription started
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionStarted"
+
+    EventSubscriptionUpdated:
+      description: event structure for subscription updated
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionUpdated"
+
+    EventSubscriptionEnded:
+      description: event structure for subscription ended
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionEnded"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Subscription management schemas
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionRequest:
+      description: The request for creating a event-type event subscription
+      type: object
+      required:
+        - sink
+        - protocol
+        - config
+        - types
+      properties:
+        protocol:
+          $ref: "#/components/schemas/Protocol"
+        sink:
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https:\/\/.+$
+          description: The address to which events shall be delivered using the selected protocol.
+          example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: "#/components/schemas/SinkCredential"
+        types:
+          description: |
+            Camara Event types eligible to be delivered by this subscription.
+            References ApiEventType (not the full NotificationEvent union) —
+            subscription requests target API-specific events only; lifecycle
+            events are server-initiated and cannot be subscribed to directly.
+            Note: the maximum number of event types per subscription will be decided at API project level.
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            $ref: "#/components/schemas/ApiEventType"
+        config:
+          $ref: "#/components/schemas/Config"
+      discriminator:
+        propertyName: protocol
+        mapping:
+          HTTP: "#/components/schemas/HTTPSubscriptionRequest"
+          MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
+          MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
+          AMQP: "#/components/schemas/AMQPSubscriptionRequest"
+          NATS: "#/components/schemas/NATSSubscriptionRequest"
+          KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
+
+    Protocol:
+      type: string
+      enum: ["HTTP", "MQTT3", "MQTT5", "AMQP", "NATS", "KAFKA"]
+      description: Identifier of a delivery protocol. Only HTTP is allowed for now
+      example: "HTTP"
+
+    Config:
+      description: |
+        Implementation-specific configuration parameters needed by the subscription manager for acquiring events.
+        In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`.
+        Specific event type attributes must be defined in `subscriptionDetail`.
+      type: object
+      required:
+        - subscriptionDetail
+      properties:
+        subscriptionDetail:
+          $ref: "#/components/schemas/CreateSubscriptionDetail"
+        subscriptionExpireTime:
+          type: string
+          format: date-time
+          maxLength: 64
+          example: 2023-01-17T13:18:23.682Z
+          description: The subscription expiration time (in date-time format) requested by the API consumer.
+        subscriptionMaxEvents:
+          type: integer
+          format: int32
+          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer.
+          minimum: 1
+          maximum: 1000000
+          example: 5
+        initialEvent:
+          type: boolean
+          description: |
+            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is
+            created and current situation reflects event request.
+
+    SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
+      type: object
+      properties:
+        credentialType:
+          type: string
+          enum:
+            - PLAIN
+            - ACCESSTOKEN
+            - PRIVATE_KEY_JWT
+          description: The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT for now
+      discriminator:
+        propertyName: credentialType
+        mapping:
+          PLAIN: "#/components/schemas/PlainCredential"
+          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
+          PRIVATE_KEY_JWT: "#/components/schemas/PrivateKeyJWTCredential"
+      required:
+        - credentialType
+
+    PlainCredential:
+      type: object
+      description: A plain credential as a combination of an identifier and a secret.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          required:
+            - identifier
+            - secret
+          properties:
+            identifier:
+              description: The identifier might be an account or username.
+              type: string
+              maxLength: 256
+            secret:
+              description: The secret might be a password or passphrase.
+              type: string
+              maxLength: 512
+
+    AccessTokenCredential:
+      type: object
+      description: An access token credential.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          properties:
+            accessToken:
+              description: REQUIRED. An access token is a token granting access to the target resource.
+              type: string
+              maxLength: 4096
+            accessTokenExpiresUtc:
+              type: string
+              format: date-time
+              maxLength: 64
+              description: REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+              example: "2023-07-03T12:27:08.312Z"
+            accessTokenType:
+              description: REQUIRED. Type of the access token (See OAuth 2.0).
+              type: string
+              enum:
+                - bearer
+          required:
+            - accessToken
+            - accessTokenExpiresUtc
+            - accessTokenType
+
+    PrivateKeyJWTCredential:
+      type: object
+      description: Use PRIVATE_KEY_JWT to get an access token.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+
+    CreateSubscriptionDetail:
+      description: The detail of the requested event subscription.
+      type: object
+
+    Subscription:
+      description: Represents a event-type subscription.
+      type: object
+      required:
+        - sink
+        - protocol
+        - config
+        - types
+        - id
+      properties:
+        protocol:
+          $ref: "#/components/schemas/Protocol"
+        sink:
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https:\/\/.+$
+          description: The address to which events shall be delivered using the selected protocol.
+          example: "https://endpoint.example.com/sink"
+        types:
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            $ref: "#/components/schemas/ApiEventType"
+        config:
+          $ref: '#/components/schemas/Config'
+        id:
+          $ref: '#/components/schemas/SubscriptionId'
+        startsAt:
+          type: string
+          format: date-time
+          maxLength: 64
+          description: Date when the event subscription will begin/began.
+          example: "2023-07-03T12:27:08.312Z"
+        expiresAt:
+          type: string
+          format: date-time
+          maxLength: 64
+          description: Date when the event subscription will expire.
+          example: "2023-07-03T12:27:08.312Z"
+        status:
+          type: string
+          description: |-
+            Current status of the subscription. Details:
+              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but not finished yet.
+              - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
+              - `INACTIVE`: Subscription is temporarily inactive.
+              - `EXPIRED`: Subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED`.
+              - `DELETED`: Subscription is ended as deleted.
+          enum:
+            - ACTIVATION_REQUESTED
+            - ACTIVE
+            - EXPIRED
+            - INACTIVE
+            - DELETED
+      discriminator:
+        propertyName: protocol
+        mapping:
+          HTTP: '#/components/schemas/HTTPSubscriptionResponse'
+          MQTT3: '#/components/schemas/MQTTSubscriptionResponse'
+          MQTT5: '#/components/schemas/MQTTSubscriptionResponse'
+          AMQP: '#/components/schemas/AMQPSubscriptionResponse'
+          NATS: '#/components/schemas/NATSSubscriptionResponse'
+          KAFKA: '#/components/schemas/ApacheKafkaSubscriptionResponse'
+
+    SubscriptionAsync:
+      description: Response for a event-type subscription request managed asynchronously
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/SubscriptionId"
+
+    SubscriptionId:
+      type: string
+      maxLength: 256
+      description: The unique identifier of the subscription in the scope of the subscription manager.
+      example: qs15-h556-rt89-1298
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Subscription lifecycle data payloads (Commonalities-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionStarted:
+      description: Event detail structure for subscription started event
+      type: object
+      required:
+        - initiationReason
+        - subscriptionId
+      properties:
+        initiationReason:
+          $ref: "#/components/schemas/InitiationReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        initiationDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription initiation
+
+    InitiationReason:
+      type: string
+      description: |
+        - SUBSCRIPTION_CREATED - Subscription created by API Server
+      enum:
+        - SUBSCRIPTION_CREATED
+
+    SubscriptionUpdated:
+      description: Event detail structure for subscription updated event
+      type: object
+      required:
+        - updateReason
+        - subscriptionId
+      properties:
+        updateReason:
+          $ref: "#/components/schemas/UpdateReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        updateDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription update
+
+    UpdateReason:
+      type: string
+      description: |
+        - SUBSCRIPTION_ACTIVE - API server transitioned subscription status to `ACTIVE`
+        - SUBSCRIPTION_INACTIVE - API server transitioned subscription status to `INACTIVE`
+      enum:
+        - SUBSCRIPTION_ACTIVE
+        - SUBSCRIPTION_INACTIVE
+
+    SubscriptionEnded:
+      description: Event detail structure for subscription ended event
+      type: object
+      required:
+        - terminationReason
+        - subscriptionId
+      properties:
+        terminationReason:
+          $ref: "#/components/schemas/TerminationReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        terminationDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription termination
+
+    TerminationReason:
+      type: string
+      description: |
+        - NETWORK_TERMINATED - API server stopped sending notification
+        - SUBSCRIPTION_EXPIRED - Subscription expire time has been reached
+        - MAX_EVENTS_REACHED - Maximum number of events has been reached
+        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential expiration time has been reached
+        - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
+      enum:
+        - MAX_EVENTS_REACHED
+        - NETWORK_TERMINATED
+        - SUBSCRIPTION_EXPIRED
+        - ACCESS_TOKEN_EXPIRED
+        - SUBSCRIPTION_DELETED
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Common value object schemas
+    # ─────────────────────────────────────────────────────────────────────────
+
     ErrorInfo:
       type: object
-      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
+      description: A structured error response providing details about a failed request.
       required:
         - status
         - code
@@ -275,456 +840,24 @@ components:
       maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
-    SubscriptionRequest:
-      description: The request for creating a event-type event subscription
-      type: object
-      required:
-        - sink
-        - protocol
-        - config
-        - types
-      properties:
-        protocol:
-          $ref: "#/components/schemas/Protocol"
-        sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          $ref: "#/components/schemas/SinkCredential"
-        types:
-          description: |
-            Camara Event types eligible to be delivered by this subscription.
-            Note: the maximum number of event types per subscription will be decided at API project level
-          type: array
-          minItems: 1
-          maxItems: 1
-          items:
-            $ref: "#/components/schemas/SubscriptionEventType"
-        config:
-          $ref: "#/components/schemas/Config"
-      discriminator:
-        propertyName: protocol
-        mapping:
-          HTTP: "#/components/schemas/HTTPSubscriptionRequest"
-          MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
-          MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
-          AMQP: "#/components/schemas/AMQPSubscriptionRequest"
-          NATS: "#/components/schemas/NATSSubscriptionRequest"
-          KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
-
-    Protocol:
-      type: string
-      enum: ["HTTP", "MQTT3", "MQTT5", "AMQP", "NATS", "KAFKA"]
-      description: Identifier of a delivery protocol. Only HTTP is allowed for now
-      example: "HTTP"
-
-    Config:
-      description: |
-        Implementation-specific configuration parameters needed by the subscription manager for acquiring events.
-        In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`
-        Specific event type attributes must be defined in `subscriptionDetail`
-        Note: if a request is performed for several event type, all subscribed event will use same `config` parameters.
-      type: object
-      required:
-        - subscriptionDetail
-      properties:
-        subscriptionDetail:
-          $ref: "#/components/schemas/CreateSubscriptionDetail"
-        subscriptionExpireTime:
-          type: string
-          format: date-time
-          maxLength: 64
-          example: 2023-01-17T13:18:23.682Z
-          description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Up to API project decision to keep it.
-        subscriptionMaxEvents:
-          type: integer
-          format: int32
-          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
-          minimum: 1
-          maximum: 1000000
-          example: 5
-        initialEvent:
-          type: boolean
-          description: |
-            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.
-            Example: Consumer request Roaming event. If consumer sets initialEvent to true and device is in roaming situation, an event is triggered
-            Up to API project decision to keep it.
-
-    SinkCredential:
-      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-      type: object
-      properties:
-        credentialType:
-          type: string
-          enum:
-            - PLAIN
-            - ACCESSTOKEN
-            - PRIVATE_KEY_JWT
-          description: |
-            The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT for now
-      discriminator:
-        propertyName: credentialType
-        mapping:
-          PLAIN: "#/components/schemas/PlainCredential"
-          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
-          PRIVATE_KEY_JWT: "#/components/schemas/PrivateKeyJWTCredential"
-      required:
-        - credentialType
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-              maxLength: 256
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
-              maxLength: 512
-    AccessTokenCredential:
-      type: object
-      description: An access token credential. This type of credential is meant to be used by API Consumers that have limited capabilities to handle authorization requests. 
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          properties:
-            accessToken:
-              description: REQUIRED. An access token is a token granting access to the target resource.
-              type: string
-              maxLength: 4096
-            accessTokenExpiresUtc:
-              type: string
-              format: date-time
-              maxLength: 64
-              description: |
-                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
-                In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
-                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
-                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-              example: "2023-07-03T12:27:08.312Z"
-            accessTokenType:
-              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
-              type: string
-              enum:
-                - bearer
-          required:
-            - accessToken
-            - accessTokenExpiresUtc
-            - accessTokenType
-    PrivateKeyJWTCredential:
-      type: object
-      description: Use PRIVATE_KEY_JWT to get an access token. The authorization server information needed for this type of sink credential (token endpoint, client ID, JWKS URL) is shared upfront between the client and the CAMARA entity. This type of credential is to be used by clients that have an authorization server. 
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-    CreateSubscriptionDetail:
-      description: The detail of the requested event subscription.
-      type: object
-
-    EventTypeNotification:
-      type: string
-      description: |
-        event-type - Event triggered when an event-type event occurred. Several event-type could be defined.
-
-        - subscription-started: Event triggered when the subscription starts
-        - subscription-updated: Event triggered when the subscription is updated
-        - subscription-ended: Event triggered when the subscription ends
-      enum:
-        - org.camaraproject.api-name.v0.event-type1
-        - org.camaraproject.api-name.v0.event-type2
-        - org.camaraproject.api-name.v0.subscription-started
-        - org.camaraproject.api-name.v0.subscription-updated
-        - org.camaraproject.api-name.v0.subscription-ended
-
-    SubscriptionEventType:
-      type: string
-      description: |
-        event-type that could be subscribed through this subscription. Several event-type could be defined.
-      enum:
-        - org.camaraproject.api-name.v0.event-type1
-        - org.camaraproject.api-name.v0.event-type2
-
-    Subscription:
-      description: Represents a event-type subscription.
-      type: object
-      required:
-        - sink
-        - protocol
-        - config
-        - types
-        - id
-      properties:
-        protocol:
-          $ref: "#/components/schemas/Protocol"
-        sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
-        types:
-          description: |
-            Camara Event types eligible to be delivered by this subscription.
-            Note: the maximum number of event types per subscription will be decided at API project level
-          type: array
-          minItems: 1
-          maxItems: 1
-          items:
-            $ref: "#/components/schemas/SubscriptionEventType"
-        config:
-          $ref: '#/components/schemas/Config'
-        id:
-          $ref: '#/components/schemas/SubscriptionId'
-        startsAt:
-          type: string
-          format: date-time
-          maxLength: 64
-          description: |
-            Date when the event subscription will begin/began
-            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-          example: "2023-07-03T12:27:08.312Z"
-        expiresAt:
-          type: string
-          format: date-time
-          maxLength: 64
-          description: |
-            Date when the event subscription will expire. Only provided when `subscriptionExpireTime` is indicated by API client or Telco Operator has specific policy about that.
-            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-          example: "2023-07-03T12:27:08.312Z"
-        status:
-          type: string
-          description: |-
-            Current status of the subscription - Management of Subscription State engine is not mandatory for now. Note not all statuses may be considered to be implemented. Details:
-              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but subscription creation process is not finished yet.
-              - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
-              - `INACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
-              - `EXPIRED`: Subscription is ended (no longer active). This status applies when subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED` event.
-              - `DELETED`: Subscription is ended as deleted (no longer active). This status applies when subscription information is kept (i.e. subscription workflow is no longer active but its meta-information is kept).
-          enum:
-            - ACTIVATION_REQUESTED
-            - ACTIVE
-            - EXPIRED
-            - INACTIVE
-            - DELETED
-      discriminator:
-        propertyName: protocol
-        mapping:
-          HTTP: '#/components/schemas/HTTPSubscriptionResponse'
-          MQTT3: '#/components/schemas/MQTTSubscriptionResponse'
-          MQTT5: '#/components/schemas/MQTTSubscriptionResponse'
-          AMQP: '#/components/schemas/AMQPSubscriptionResponse'
-          NATS: '#/components/schemas/NATSSubscriptionResponse'
-          KAFKA: '#/components/schemas/ApacheKafkaSubscriptionResponse'
-
-    SubscriptionAsync:
-      description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          $ref: "#/components/schemas/SubscriptionId"
-
-    SubscriptionId:
-      type: string
-      maxLength: 256
-      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, it SHALL be referred to as `subscriptionId` as per the Commonalities Event Notification Model.
-      example: qs15-h556-rt89-1298
-
-    CloudEvent:
-      type: object
-      description: The notification callback content
-      required:
-        - id
-        - source
-        - specversion
-        - type
-        - time
-      properties:
-        id:
-          type: string
-          maxLength: 256
-          description: identifier of this event, that must be unique in the source context.
-        source:
-          $ref: "#/components/schemas/Source"
-        type:
-          $ref: "#/components/schemas/EventTypeNotification"
-        specversion:
-          type: string
-          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
-          enum:
-            - "1.0"
-        datacontenttype:
-          type: string
-          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
-          enum:
-            - application/json
-        data:
-          type: object
-          description: Event details payload described in each CAMARA API and referenced by its type
-        time:
-          $ref: "#/components/schemas/DateTime"
-      discriminator:
-        propertyName: "type"
-        mapping:
-          org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
-          org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
-          org.camaraproject.api-name.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
-          org.camaraproject.api-name.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
-          org.camaraproject.api-name.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
-
     Source:
       type: string
       format: uri-reference
       minLength: 1
       maxLength: 2048
-      description: |
-        Identifies the context in which an event happened - be a non-empty `URI-reference` like:
-        - URI with a DNS authority:
-          * https://github.com/cloudevents
-          * mailto:cncf-wg-serverless@lists.cncf.io
-        - Universally-unique URN with a UUID:
-          * urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
-        - Application-specific identifier:
-          * /cloudevents/spec/pull/123
-          * 1-555-123-4567
+      description: Identifies the context in which an event happened.
       example: "https://notificationSendServer12.example.com"
 
     DateTime:
       type: string
       format: date-time
       maxLength: 64
-      description: Timestamp of when the occurrence happened. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      description: Timestamp of when the occurrence happened. It must follow RFC 3339 and must have time zone.
       example: "2018-04-05T17:31:00Z"
 
-    EventApiSpecific1:
-      description: event structure for event-type event 1
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-
-    EventApiSpecific2:
-      description: event structure for event-type event 2
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-
-    EventSubscriptionStarted:
-      description: event structure for event subscription started
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionStarted"
-
-    SubscriptionStarted:
-      description: Event detail structure for subscription started event
-      type: object
-      required:
-        - initiationReason
-        - subscriptionId
-      properties:
-        initiationReason:
-          $ref: "#/components/schemas/InitiationReason"
-        subscriptionId:
-          $ref: "#/components/schemas/SubscriptionId"
-        initiationDescription:
-          type: string
-          maxLength: 512
-          description: Description of subscription initiation
-
-    InitiationReason:
-      type: string
-      description: |
-        - SUBSCRIPTION_CREATED - Subscription created by API Server
-      enum:
-        - SUBSCRIPTION_CREATED
-
-    EventSubscriptionUpdated:
-      description: event structure for event subscription updated
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionUpdated"
-
-    SubscriptionUpdated:
-      description: Event detail structure for subscription updated event
-      type: object
-      required:
-        - updateReason
-        - subscriptionId
-      properties:
-        updateReason:
-          $ref: "#/components/schemas/UpdateReason"
-        subscriptionId:
-          $ref: "#/components/schemas/SubscriptionId"
-        updateDescription:
-          type: string
-          maxLength: 512
-          description: Description of subscription update
-
-    UpdateReason:
-      type: string
-      description: |
-        - SUBSCRIPTION_ACTIVE - API server transitioned susbcription status to `ACTIVE`
-        - SUBSCRIPTION_INACTIVE - API server transitioned susbcription status to `INACTIVE`
-      enum:
-        - SUBSCRIPTION_ACTIVE
-        - SUBSCRIPTION_INACTIVE
-
-    EventSubscriptionEnded:
-      description: event structure for event subscription ended
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionEnded"
-
-    SubscriptionEnded:
-      description: Event detail structure for subscription ended event
-      type: object
-      required:
-        - terminationReason
-        - subscriptionId
-      properties:
-        terminationReason:
-          $ref: "#/components/schemas/TerminationReason"
-        subscriptionId:
-          $ref: "#/components/schemas/SubscriptionId"
-        terminationDescription:
-          type: string
-          maxLength: 512
-          description: Description of subscription termination
-
-    TerminationReason:
-      type: string
-      description: |
-        - NETWORK_TERMINATED - API server stopped sending notification
-        - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
-        - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
-        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester with credential type `ACCESSTOKEN`) expiration time has been reached
-        - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
-      enum:
-        - MAX_EVENTS_REACHED
-        - NETWORK_TERMINATED
-        - SUBSCRIPTION_EXPIRED
-        - ACCESS_TOKEN_EXPIRED
-        - SUBSCRIPTION_DELETED
+    # ─────────────────────────────────────────────────────────────────────────
+    # Protocol-specific subscription schemas
+    # ─────────────────────────────────────────────────────────────────────────
 
     HTTPSubscriptionRequest:
       allOf:
@@ -747,10 +880,7 @@ components:
       properties:
         headers:
           type: object
-          description: |-
-            A set of key/value pairs that is copied into the HTTP request as custom headers.
-
-            NOTE: Use/Applicability of this concept has not been discussed in Commonalities. When required by an API project as an option to meet a UC/Requirement, please generate an issue for Commonalities discussion about it.
+          description: A set of key/value pairs that is copied into the HTTP request as custom headers.
           additionalProperties:
             type: string
             maxLength: 512
@@ -898,6 +1028,7 @@ components:
           description: NATS subject
       required:
         - subject
+
   responses:
     CreateSubscriptionBadRequest400:
       description: Problem with the client request
@@ -942,7 +1073,7 @@ components:
                 code: INVALID_PROTOCOL
                 message: Only HTTP is supported
             GENERIC_400_INVALID_CREDENTIAL:
-              description: Invalid sink credential type 
+              description: Invalid sink credential type
               value:
                 status: 400
                 code: INVALID_CREDENTIAL
@@ -1029,7 +1160,7 @@ components:
                       - UNAUTHENTICATED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
+              description: Request cannot be authenticated
               value:
                 status: 401
                 code: UNAUTHENTICATED
@@ -1054,11 +1185,11 @@ components:
                       - PERMISSION_DENIED
           examples:
             GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              description: Permission denied
               value:
                 status: 403
                 code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.       
+                message: Client does not have sufficient permissions to perform this action.
     SubscriptionPermissionDenied403:
       description: Client does not have sufficient permission
       headers:
@@ -1080,7 +1211,7 @@ components:
                       - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              description: Permission denied
               value:
                 status: 403
                 code: PERMISSION_DENIED
@@ -1137,7 +1268,7 @@ components:
                       - ALREADY_EXISTS
           examples:
             GENERIC_409_ABORTED:
-              description: Concurreny of processes of the same nature/scope
+              description: Concurrency of processes of the same nature/scope
               value:
                 status: 409
                 code: ABORTED
@@ -1168,7 +1299,7 @@ components:
                       - GONE
           examples:
             GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
+              description: Use in notifications flow to indicate callback is no longer available
               value:
                 status: 410
                 code: GONE
@@ -1205,7 +1336,7 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              description: An identifier is not included in the request
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
@@ -1217,7 +1348,7 @@ components:
                 code: UNSUPPORTED_IDENTIFIER
                 message: The identifier provided is not supported.
             GENERIC_422_UNNECESSARY_IDENTIFIER:
-              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              description: An explicit identifier is provided when device is already identified from the access token
               value:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
@@ -1267,7 +1398,7 @@ components:
                 code: QUOTA_EXCEEDED
                 message: Out of resource quota.
             GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits
               value:
                 status: 429
                 code: TOO_MANY_REQUESTS

--- a/artifacts/camara-cloudevents/event-subscription-template.yaml
+++ b/artifacts/camara-cloudevents/event-subscription-template.yaml
@@ -5,17 +5,6 @@ info:
     This file is a template for CAMARA API explicit subscription endpoint and for Notification model.
     Additional information are provided in [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md).
 
-    ## Schema layering
-
-    | Schema | Owner | Responsibility |
-    |---|---|---|
-    | `CloudEvent` | Commonalities | CloudEvents 1.0 envelope — no CAMARA-specific constraints |
-    | `ApiNotificationEvent` | API project | Constrains `type` to `ApiEventType`; owns the discriminator mapping |
-    | `ApiEventType` | API project | Enum of valid API-specific event type strings |
-    | `SubscriptionLifecycleEvent` | Commonalities | Constrains `type` to `SubscriptionLifecycleEventType`; owns lifecycle discriminator |
-    | `SubscriptionLifecycleEventType` | Commonalities | Enum: subscription-started, subscription-updated, subscription-ended |
-    | `NotificationEvent` | API project | `oneOf` union at the callback endpoint — enumerates valid groups |
-
     Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<event-version>.<event-name>``
 
     Note on ``security`` - ``openId`` scope: The value in this yaml `api-name:event-type1:grant-level` must be replaced accordingly to the format defined in the guideline document.
@@ -29,14 +18,14 @@ info:
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/apiRepository
-
+  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
 servers:
   - url: "{apiRoot}/api-name/vx.y"
+    # api-name and version should be valued accordingly to the CAMARA API versioning guidelines, e.g. for a version x.y.z, put v0.y for x=0 or just vx for x>0 in the url.
     variables:
       apiRoot:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
-
 tags:
   - name: <apiName> Subscription
     description: Operations to manage event subscriptions on event-type event
@@ -69,7 +58,7 @@ paths:
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
                 The apiName server will call this endpoint whenever a apiName event occurs.
-                `operationId` value will have to be replaced accordingly with WG API specific semantic.
+                `operationId` value will have to be replaced accordingly with WG API specific semantic
               operationId: postNotification
               parameters:
                 - $ref: "#/components/parameters/x-correlator"
@@ -78,7 +67,7 @@ paths:
                 content:
                   application/cloudevents+json:
                     schema:
-                      $ref: "#/components/schemas/NotificationEvent"
+                      $ref: "#/components/schemas/CloudEvent"
               responses:
                 "204":
                   description: Successful notification
@@ -130,7 +119,6 @@ paths:
           $ref: "#/components/responses/CreateSubscriptionUnprocessableEntity422"
         "429":
           $ref: "#/components/responses/Generic429"
-
     get:
       tags:
         - <apiName> Subscription
@@ -162,7 +150,6 @@ paths:
           $ref: "#/components/responses/Generic401"
         "403":
           $ref: "#/components/responses/Generic403"
-
   /subscriptions/{subscriptionId}:
     get:
       tags:
@@ -194,7 +181,6 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
-
     delete:
       tags:
         - <apiName> Subscription
@@ -230,7 +216,6 @@ paths:
           $ref: "#/components/responses/Generic403"
         "404":
           $ref: "#/components/responses/Generic404"
-
 components:
   securitySchemes:
     openId:
@@ -240,7 +225,6 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
-
   parameters:
     SubscriptionId:
       name: subscriptionId
@@ -255,236 +239,41 @@ components:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
-
   headers:
     x-correlator:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
-
   schemas:
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Layer 0 — CloudEvents 1.0 envelope (Commonalities-owned, never modified)
-    #
-    # Knows nothing about CAMARA event types, data payloads, or discriminator
-    # mappings. Any CAMARA API that needs to send a notification starts here.
-    # This schema MUST NOT be modified regardless of how many APIs or event
-    # types are added to the platform.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    CloudEvent:
+    ErrorInfo:
       type: object
-      description: |
-        CloudEvents 1.0 specification envelope.
-        This schema is the stable base for all CAMARA event notifications.
-        It imposes no constraints on `type` values or `data` structure —
-        those concerns belong to the API-specific and lifecycle group schemas.
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
       required:
-        - id
-        - source
-        - specversion
-        - type
-        - time
+        - status
+        - code
+        - message
       properties:
-        id:
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
           type: string
-          maxLength: 256
-          description: Identifier of this event, unique within the source context.
-        source:
-          $ref: "#/components/schemas/Source"
-        specversion:
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
           type: string
-          description: Version of the specification to which this event conforms.
-          enum:
-            - "1.0"
-        type:
-          type: string
-          description: |
-            Identifies the event type. CAMARA APIs use reverse-DNS notation:
-            org.camaraproject.<api-name>.<event-version>.<event-name>
-            The api-name segment makes each type globally unique across API groups.
-        datacontenttype:
-          type: string
-          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
-          enum:
-            - application/json
-        data:
-          type: object
-          description: Event details payload. Structure is defined by each concrete event schema.
-        time:
-          $ref: "#/components/schemas/DateTime"
+          maxLength: 512
+          description: A human-readable description of what the event represents
 
-    # ─────────────────────────────────────────────────────────────────────────
-    # Layer 1a — API-specific event group (API project-owned)
-    #
-    # Extends CloudEvent via allOf and does exactly two things:
-    #   1. Constrains `type` to its own ApiEventType enum
-    #   2. Owns the discriminator mapping from each enum value to a concrete schema
-    #
-    # Adding a new event type requires only: adding a value to ApiEventType and
-    # adding a discriminator mapping entry here. CloudEvent is never touched.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    ApiNotificationEvent:
-      description: |
-        API-specific notification event group.
-        Extends the CloudEvent envelope and constrains `type` to the set of
-        event types defined by this API project.
-        Adding a new event type only requires updating ApiEventType and the
-        discriminator mapping below — the CloudEvent base never changes.
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            type:
-              $ref: "#/components/schemas/ApiEventType"
-      discriminator:
-        propertyName: type
-        mapping:
-          org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
-          org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
-
-    ApiEventType:
+    XCorrelator:
       type: string
-      description: |
-        Enum of API-specific event type strings for this API project.
-        The reverse-DNS prefix org.camaraproject.<api-name> makes each value
-        globally unique, so two different API groups can independently define
-        identically-named event types without any collision risk.
-      enum:
-        - org.camaraproject.api-name.v0.event-type1
-        - org.camaraproject.api-name.v0.event-type2
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Layer 1b — Subscription lifecycle event group (Commonalities-owned)
-    #
-    # Common to every CAMARA API that supports subscriptions.
-    # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
-    # and owns the lifecycle discriminator mapping.
-    #
-    # API projects reference this group via NotificationEvent but never modify it.
-    # In a split-file layout this schema lives in CAMARA_Events_common.yaml.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    SubscriptionLifecycleEvent:
-      description: |
-        Subscription lifecycle event group, common to all CAMARA APIs that
-        support explicit subscriptions.
-        Extends the CloudEvent envelope and constrains `type` to the set of
-        lifecycle event types managed by Commonalities.
-        API projects include this group via NotificationEvent.oneOf and must
-        not modify it.
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            type:
-              $ref: "#/components/schemas/SubscriptionLifecycleEventType"
-      discriminator:
-        propertyName: type
-        mapping:
-          org.camaraproject.api-name.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
-          org.camaraproject.api-name.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
-          org.camaraproject.api-name.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
-
-    SubscriptionLifecycleEventType:
-      type: string
-      description: |
-        Enum of subscription lifecycle event type strings.
-        These are managed by Commonalities and are identical across all CAMARA
-        APIs that support explicit subscriptions.
-        Kept as a separate named schema so the set of valid lifecycle type
-        strings can be referenced independently from the discriminated schema.
-      enum:
-        - org.camaraproject.api-name.v0.subscription-started
-        - org.camaraproject.api-name.v0.subscription-updated
-        - org.camaraproject.api-name.v0.subscription-ended
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Layer 2 — Callback union (API project-owned)
-    #
-    # oneOf over all valid event groups at the callback endpoint.
-    # Owns no discriminator and applies no constraints of its own.
-    # Its only job is to enumerate which groups are valid for this API.
-    #
-    # To add a new event group: add it to the oneOf list. That is the only
-    # change required at this layer.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    NotificationEvent:
-      description: |
-        Union of all valid notification event groups at the callback endpoint.
-        This schema owns no discriminator — routing within each group is
-        handled by ApiNotificationEvent and SubscriptionLifecycleEvent
-        respectively. Its only responsibility is to enumerate which groups
-        are valid payloads for this API's notification callback.
-      oneOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Concrete event schemas — API-specific (API project-owned)
-    # ─────────────────────────────────────────────────────────────────────────
-
-    EventApiSpecific1:
-      description: Event structure for event-type1
-      allOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - type: object
-          properties:
-            data:
-              type: object
-              description: |
-                Event-specific payload for event-type1.
-                Replace with the actual data schema for this event type.
-
-    EventApiSpecific2:
-      description: Event structure for event-type2
-      allOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - type: object
-          properties:
-            data:
-              type: object
-              description: |
-                Event-specific payload for event-type2.
-                Replace with the actual data schema for this event type.
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Concrete event schemas — Subscription lifecycle (Commonalities-owned)
-    # ─────────────────────────────────────────────────────────────────────────
-
-    EventSubscriptionStarted:
-      description: event structure for subscription started
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionStarted"
-
-    EventSubscriptionUpdated:
-      description: event structure for subscription updated
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionUpdated"
-
-    EventSubscriptionEnded:
-      description: event structure for subscription ended
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/SubscriptionEnded"
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Subscription management schemas
-    # ─────────────────────────────────────────────────────────────────────────
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
+      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
+      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
     SubscriptionRequest:
       description: The request for creating a event-type event subscription
@@ -539,8 +328,9 @@ components:
     Config:
       description: |
         Implementation-specific configuration parameters needed by the subscription manager for acquiring events.
-        In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`.
+        In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`
         Specific event type attributes must be defined in `subscriptionDetail`.
+        Note: if a request is performed for several event types, all subscribed events will use same `config` parameters.
       type: object
       required:
         - subscriptionDetail
@@ -552,19 +342,20 @@ components:
           format: date-time
           maxLength: 64
           example: 2023-01-17T13:18:23.682Z
-          description: The subscription expiration time (in date-time format) requested by the API consumer.
+          description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Up to API project decision to keep it.
         subscriptionMaxEvents:
           type: integer
           format: int32
-          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer.
+          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
           minimum: 1
           maximum: 1000000
           example: 5
         initialEvent:
           type: boolean
           description: |
-            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is
-            created and current situation reflects event request.
+            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.
+            Example: Consumer request Roaming event. If consumer sets initialEvent to true and device is in roaming situation, an event is triggered
+            Up to API project decision to keep it.
 
     SinkCredential:
       description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
@@ -576,7 +367,8 @@ components:
             - PLAIN
             - ACCESSTOKEN
             - PRIVATE_KEY_JWT
-          description: The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT for now
+          description: |
+            The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT for now
       discriminator:
         propertyName: credentialType
         mapping:
@@ -585,7 +377,6 @@ components:
           PRIVATE_KEY_JWT: "#/components/schemas/PrivateKeyJWTCredential"
       required:
         - credentialType
-
     PlainCredential:
       type: object
       description: A plain credential as a combination of an identifier and a secret.
@@ -604,10 +395,9 @@ components:
               description: The secret might be a password or passphrase.
               type: string
               maxLength: 512
-
     AccessTokenCredential:
       type: object
-      description: An access token credential.
+      description: An access token credential. This type of credential is meant to be used by API Consumers that have limited capabilities to handle authorization requests.
       allOf:
         - $ref: "#/components/schemas/SinkCredential"
         - type: object
@@ -620,10 +410,14 @@ components:
               type: string
               format: date-time
               maxLength: 64
-              description: REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+              description: |
+                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+                In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
+                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
+                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
               example: "2023-07-03T12:27:08.312Z"
             accessTokenType:
-              description: REQUIRED. Type of the access token (See OAuth 2.0).
+              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
               type: string
               enum:
                 - bearer
@@ -631,16 +425,70 @@ components:
             - accessToken
             - accessTokenExpiresUtc
             - accessTokenType
-
     PrivateKeyJWTCredential:
       type: object
-      description: Use PRIVATE_KEY_JWT to get an access token.
+      description: Use PRIVATE_KEY_JWT to get an access token. The authorization server information needed for this type of sink credential (token endpoint, client ID, JWKS URL) is shared upfront between the client and the CAMARA entity. This type of credential is to be used by clients that have an authorization server.
       allOf:
         - $ref: "#/components/schemas/SinkCredential"
-
     CreateSubscriptionDetail:
       description: The detail of the requested event subscription.
       type: object
+
+    ApiEventType:
+      type: string
+      description: |
+        Enum of API-specific event type strings for this API project.
+        The reverse-DNS prefix org.camaraproject.<api-name> makes each value
+        globally unique, so two different API groups can independently define
+        identically-named event types without any collision risk.
+      enum:
+        - org.camaraproject.api-name.v0.event-type1
+        - org.camaraproject.api-name.v0.event-type2
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Subscription lifecycle event group (Commonalities-owned)
+    #
+    # Common to every CAMARA API that supports subscriptions.
+    # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
+    # and owns the lifecycle discriminator mapping.
+    #
+    # API projects reference this group via NotificationEvent but never modify it.
+    # In a split-file layout this schema lives in CAMARA_Events_common.yaml.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionLifecycleEvent:
+      description: |
+        Subscription lifecycle event group, common to all CAMARA APIs that
+        support explicit subscriptions.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        lifecycle event types managed by Commonalities.
+        API projects include this group via NotificationEvent.oneOf and must
+        not modify it.
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/SubscriptionLifecycleEventType"
+      discriminator:
+        propertyName: type
+        mapping:
+          org.camaraproject.api-name.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
+          org.camaraproject.api-name.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
+          org.camaraproject.api-name.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
+
+    SubscriptionLifecycleEventType:
+      type: string
+      description: |
+        Enum of subscription lifecycle event type strings.
+        These are managed by Commonalities and are identical across all CAMARA
+        APIs that support explicit subscriptions.
+        Kept as a separate named schema so the set of valid lifecycle type
+        strings can be referenced independently from the discriminated schema.
+      enum:
+        - org.camaraproject.api-name.v0.subscription-started
+        - org.camaraproject.api-name.v0.subscription-updated
+        - org.camaraproject.api-name.v0.subscription-ended
 
     Subscription:
       description: Represents a event-type subscription.
@@ -662,6 +510,9 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         types:
+          description: |
+            Camara Event types eligible to be delivered by this subscription.
+            Note: the maximum number of event types per subscription will be decided at API project level
           type: array
           minItems: 1
           maxItems: 1
@@ -675,23 +526,27 @@ components:
           type: string
           format: date-time
           maxLength: 64
-          description: Date when the event subscription will begin/began.
+          description: |
+            Date when the event subscription will begin/began
+            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
           example: "2023-07-03T12:27:08.312Z"
         expiresAt:
           type: string
           format: date-time
           maxLength: 64
-          description: Date when the event subscription will expire.
+          description: |
+            Date when the event subscription will expire. Only provided when `subscriptionExpireTime` is indicated by API client or Telco Operator has specific policy about that.
+            It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
           example: "2023-07-03T12:27:08.312Z"
         status:
           type: string
           description: |-
-            Current status of the subscription. Details:
-              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but not finished yet.
+            Current status of the subscription - Management of Subscription State engine is not mandatory for now. Note not all statuses may be considered to be implemented. Details:
+              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but subscription creation process is not finished yet.
               - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
-              - `INACTIVE`: Subscription is temporarily inactive.
-              - `EXPIRED`: Subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED`.
-              - `DELETED`: Subscription is ended as deleted.
+              - `INACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
+              - `EXPIRED`: Subscription is ended (no longer active). This status applies when subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED` event.
+              - `DELETED`: Subscription is ended as deleted (no longer active). This status applies when subscription information is kept (i.e. subscription workflow is no longer active but its meta-information is kept).
           enum:
             - ACTIVATION_REQUESTED
             - ACTIVE
@@ -709,7 +564,7 @@ components:
           KAFKA: '#/components/schemas/ApacheKafkaSubscriptionResponse'
 
     SubscriptionAsync:
-      description: Response for a event-type subscription request managed asynchronously
+      description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
       type: object
       required:
         - id
@@ -720,12 +575,165 @@ components:
     SubscriptionId:
       type: string
       maxLength: 256
-      description: The unique identifier of the subscription in the scope of the subscription manager.
+      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, it SHALL be referred to as `subscriptionId` as per the Commonalities Event Notification Model.
       example: qs15-h556-rt89-1298
 
+    CloudEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 specification envelope.
+        This schema is the stable base for all CAMARA event notifications.
+        It imposes no constraints on `type` values or `data` structure —
+        those concerns belong to the API-specific and lifecycle group schemas.
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - time
+      properties:
+        id:
+          type: string
+          maxLength: 256
+          description: Identifier of this event, unique within the source context.
+        source:
+          $ref: "#/components/schemas/Source"
+        type:
+          type: string
+          description: |
+            Identifies the event type. CAMARA APIs use reverse-DNS notation:
+            org.camaraproject.<api-name>.<event-version>.<event-name>
+            The api-name segment makes each type globally unique across API groups.
+        specversion:
+          type: string
+          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
+          enum:
+            - "1.0"
+        datacontenttype:
+          type: string
+          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+          enum:
+            - application/json
+        data:
+          type: object
+          description: Event details payload. Structure is defined by each concrete event schema.
+        time:
+          $ref: "#/components/schemas/DateTime"
     # ─────────────────────────────────────────────────────────────────────────
-    # Subscription lifecycle data payloads (Commonalities-owned)
+    # Extends CloudEvent via allOf and does exactly two things:
+    #   1. Constrains `type` to its own ApiEventType enum
+    #   2. Owns the discriminator mapping from each enum value to a concrete schema
+    #
+    # Adding a new event type requires only: adding a value to ApiEventType and
+    # adding a discriminator mapping entry here. CloudEvent is never touched.
     # ─────────────────────────────────────────────────────────────────────────
+
+    ApiNotificationEvent:
+      description: |
+        API-specific notification event group.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        event types defined by this API project.
+        Adding a new event type only requires updating ApiEventType and the
+        discriminator mapping below — the CloudEvent base never changes.
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/ApiEventType"
+      discriminator:
+        propertyName: "type"
+        mapping:
+          org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
+          org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
+
+
+    Source:
+      type: string
+      format: uri-reference
+      minLength: 1
+      maxLength: 2048
+      description: |
+        Identifies the context in which an event happened - be a non-empty `URI-reference` like:
+        - URI with a DNS authority:
+          * https://github.com/cloudevents
+          * mailto:cncf-wg-serverless@lists.cncf.io
+        - Universally-unique URN with a UUID:
+          * urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+        - Application-specific identifier:
+          * /cloudevents/spec/pull/123
+          * 1-555-123-4567
+      example: "https://notificationSendServer12.example.com"
+
+    DateTime:
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp of when the occurrence happened. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Layer 2 — Callback union (API project-owned)
+    #
+    # oneOf over all valid event groups at the callback endpoint.
+    # Owns no discriminator and applies no constraints of its own.
+    # Its only job is to enumerate which groups are valid for this API.
+    #
+    # To add a new event group: add it to the oneOf list. That is the only
+    # change required at this layer.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    NotificationEvent:
+      description: |
+        Union of all valid notification event groups at the callback endpoint.
+        This schema owns no discriminator — routing within each group is
+        handled by ApiNotificationEvent and SubscriptionLifecycleEvent
+        respectively. Its only responsibility is to enumerate which groups
+        are valid payloads for this API's notification callback.
+      oneOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — API-specific (API project-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventApiSpecific1:
+      description: event structure for event-type event 1
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: |
+                Event-specific payload for event-type1.
+                Replace with the actual data schema for this event type.
+
+    EventApiSpecific2:
+      description: event structure for event-type event 2
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: |
+                Event-specific payload for event-type2.
+                Replace with the actual data schema for this event type.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — Subscription lifecycle (Commonalities-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventSubscriptionStarted:
+      description: event structure for event subscription started
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionStarted"
 
     SubscriptionStarted:
       description: Event detail structure for subscription started event
@@ -749,6 +757,15 @@ components:
         - SUBSCRIPTION_CREATED - Subscription created by API Server
       enum:
         - SUBSCRIPTION_CREATED
+
+    EventSubscriptionUpdated:
+      description: event structure for event subscription updated
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionUpdated"
 
     SubscriptionUpdated:
       description: Event detail structure for subscription updated event
@@ -775,6 +792,15 @@ components:
         - SUBSCRIPTION_ACTIVE
         - SUBSCRIPTION_INACTIVE
 
+    EventSubscriptionEnded:
+      description: event structure for event subscription ended
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/SubscriptionEnded"
+
     SubscriptionEnded:
       description: Event detail structure for subscription ended event
       type: object
@@ -795,9 +821,9 @@ components:
       type: string
       description: |
         - NETWORK_TERMINATED - API server stopped sending notification
-        - SUBSCRIPTION_EXPIRED - Subscription expire time has been reached
-        - MAX_EVENTS_REACHED - Maximum number of events has been reached
-        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential expiration time has been reached
+        - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
+        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester with credential type `ACCESSTOKEN`) expiration time has been reached
         - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
       enum:
         - MAX_EVENTS_REACHED
@@ -805,56 +831,6 @@ components:
         - SUBSCRIPTION_EXPIRED
         - ACCESS_TOKEN_EXPIRED
         - SUBSCRIPTION_DELETED
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Common value object schemas
-    # ─────────────────────────────────────────────────────────────────────────
-
-    ErrorInfo:
-      type: object
-      description: A structured error response providing details about a failed request.
-      required:
-        - status
-        - code
-        - message
-      properties:
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 599
-          description: HTTP response status code
-        code:
-          type: string
-          maxLength: 96
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          maxLength: 512
-          description: A human-readable description of what the event represents
-
-    XCorrelator:
-      type: string
-      description: Correlator string, UUID format recommended but any string matching the pattern can be used
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      maxLength: 256
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-
-    Source:
-      type: string
-      format: uri-reference
-      minLength: 1
-      maxLength: 2048
-      description: Identifies the context in which an event happened.
-      example: "https://notificationSendServer12.example.com"
-
-    DateTime:
-      type: string
-      format: date-time
-      maxLength: 64
-      description: Timestamp of when the occurrence happened. It must follow RFC 3339 and must have time zone.
-      example: "2018-04-05T17:31:00Z"
-
     # ─────────────────────────────────────────────────────────────────────────
     # Protocol-specific subscription schemas
     # ─────────────────────────────────────────────────────────────────────────
@@ -880,7 +856,10 @@ components:
       properties:
         headers:
           type: object
-          description: A set of key/value pairs that is copied into the HTTP request as custom headers.
+          description: |-
+            A set of key/value pairs that is copied into the HTTP request as custom headers.
+
+            NOTE: Use/Applicability of this concept has not been discussed in Commonalities. When required by an API project as an option to meet a UC/Requirement, please generate an issue for Commonalities discussion about it.
           additionalProperties:
             type: string
             maxLength: 512
@@ -1160,7 +1139,7 @@ components:
                       - UNAUTHENTICATED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
@@ -1185,7 +1164,7 @@ components:
                       - PERMISSION_DENIED
           examples:
             GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
               value:
                 status: 403
                 code: PERMISSION_DENIED
@@ -1211,7 +1190,7 @@ components:
                       - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
               value:
                 status: 403
                 code: PERMISSION_DENIED
@@ -1299,7 +1278,7 @@ components:
                       - GONE
           examples:
             GENERIC_410_GONE:
-              description: Use in notifications flow to indicate callback is no longer available
+              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
               value:
                 status: 410
                 code: GONE
@@ -1336,7 +1315,7 @@ components:
                 code: SERVICE_NOT_APPLICABLE
                 message: The service is not available for the provided identifier.
             GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
               value:
                 status: 422
                 code: MISSING_IDENTIFIER
@@ -1348,7 +1327,7 @@ components:
                 code: UNSUPPORTED_IDENTIFIER
                 message: The identifier provided is not supported.
             GENERIC_422_UNNECESSARY_IDENTIFIER:
-              description: An explicit identifier is provided when device is already identified from the access token
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
               value:
                 status: 422
                 code: UNNECESSARY_IDENTIFIER
@@ -1398,7 +1377,7 @@ components:
                 code: QUOTA_EXCEEDED
                 message: Out of resource quota.
             GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
               value:
                 status: 429
                 code: TOO_MANY_REQUESTS


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Refactors the notification event schema hierarchy in the subscription template to decouple the CloudEvents 1.0 envelope from CAMARA-specific type constraints and discriminator routing.

The original `CloudEvent` schema mixed up three separate issues — the message format, the event types, and the routing rules — which made it hard to reuse the basic schema for different APIs or to add new event groups without changing shared parts.

This PR introduces a layered schema model:

- **`CloudEvent`** (Commonalities-owned) — pure CloudEvents 1.0 envelope. `type` is a`string`. No CAMARA-specific enum values, no discriminator. This schema is now stable and requires no modification regardless of how many APIs or event types are added.
- **`ApiNotificationEvent`** (API project-owned) — extends `CloudEvent` via `allOf`. Constrains `type` to `ApiEventType` and owns the discriminator mapping for API-specific concrete event schemas. Adding a new event type requires only a new enum value in `ApiEventType` and a new discriminator mapping entry here.
- **`ApiEventType`** (API project-owned) — standalone enum of API-specific event type strings. Separated from the discriminated schema so the valid type strings can be referenced independently (e.g. in `SubscriptionRequest.types`).
- **`SubscriptionLifecycleEvent`** + **`SubscriptionLifecycleEventType`** (Commonalities-owned) — structurally parallel to the API-specific group. Covers `subscription-started`, `subscription-updated`, `subscription-ended`.
- **`NotificationEvent`** (API project-owned) — `oneOf` union used as the callback `requestBody` schema. Adding a new event group requires a single line in the `oneOf`.

As a secondary fix, `SubscriptionRequest.types` and `Subscription.types` now reference `ApiEventType` instead of the previous `SubscriptionEventType` / `EventTypeNotification` enums, which incorrectly included lifecycle event types. Lifecycle events are server-initiated and must not appear as subscribable types in a POST body.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #600


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

> The callback `requestBody` schema changes from `CloudEvent` to `NotificationEvent`. For implementations that performed strict schema validation against `CloudEvent` at the callback endpoint, this is a schema reference change but not a wire-format change — valid payloads under the old schema remain valid under the new one. The `SubscriptionRequest.types` / `Subscription.types` change removes lifecycle event types from the subscribable enum; if any implementation accepted (and ignored) lifecycle types in POST body, those values would now be rejected as invalid.

#### Special notes for reviewers:

- The layering is designed for split-file use as propose in #603 : `CloudEvent`, `SubscriptionLifecycleEvent`, and `SubscriptionLifecycleEventType` are candidates for `CAMARA_event_common.yaml `; `ApiNotificationEvent`, `ApiEventType`, and `NotificationEvent` belong in the `sample-service-subscriptions.yaml`. **Note:** For  `SubscriptionLifecycleEvent`, and `SubscriptionLifecycleEventType` the special events naming pattern should be reviewed to make them reusable in the future.
- OAS 3.0 discriminators require that the `propertyName` field appear in the schema that declares the discriminator, not only in a parent via `allOf`. The `type` property override in `ApiNotificationEvent` and `SubscriptionLifecycleEvent` satisfies this constraint.
- `NotificationEvent` intentionally carries no discriminator. Without a top-level discriminator, tooling resolves the `oneOf` by evaluating each branch in order. This is correct behaviour — the two groups are distinguished by non-overlapping `type` enum values, so evaluation is unambiguous.
- The `EventApiSpecific1` / `EventApiSpecific2` concrete schemas now extend `ApiNotificationEvent` rather than `CloudEvent` directly, preserving the full inheritance chain and can be placed in `sample-event-type.yaml`.

#### Changelog input

```
refactor: decouple CloudEvent envelope from event type constraints in Event Subscription Template

```

#### Additional documentation 

