### PR TITLE
Add pagination shared components and example to artifacts

### DIFF
--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -1,612 +1,931 @@
-# NOTE: This is a template. Replace all occurrences of "sample-service-subscriptions"
-# (and its Title Case variant) with the actual API name in the appropriate casing.
-openapi: 3.0.3
 info:
-  title: Sample Service Subscription Template
+  title: CAMARA common data types
   description: |
-    This file is a template for CAMARA API explicit subscription endpoint and for Notification model.
-    Additional information are provided in [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md).
+    Common data types for CAMARA APIs.
+    This file contains Commonalities-owned schemas that are identical across all
+    CAMARA APIs, including error responses, common parameters, headers, and
+    reusable data types.
 
-    Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<event-version>.<event-name>``
-
-    Note on ``security`` - ``openId`` scope: The scope values must be replaced accordingly to the format defined in the guideline document.
-
+    API repositories place this file in `code/common/` and reference schemas
+    via `$ref: "../common/CAMARA_common.yaml#/components/schemas/<SchemaName>"`.
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
   x-camara-commonalities: 0.7.0
 
-externalDocs:
-  description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/apiRepository
-  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
-servers:
-  - url: "{apiRoot}/sample-service-subscriptions/vwip"
-    variables:
-      apiRoot:
-        default: http://localhost:9091
-        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
-tags:
-  - name: Sample Service Subscription
-    description: Operations to manage event subscriptions on event-type event
-
-paths:
-  /subscriptions:
-    post:
-      tags:
-        - Sample Service Subscription
-      summary: "Create a sample service event subscription"
-      description: Create a sample service event subscription
-      operationId: createSampleServiceSubscription
-      parameters:
-        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-      security:
-        - openId:
-            - sample-service-subscriptions:event-type1:grant-level
-            - sample-service-subscriptions:event-type2:grant-level
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SubscriptionRequest"
-        required: true
-      callbacks:
-        notifications:
-          "{$request.body#/sink}":
-            post:
-              summary: "notifications callback"
-              description: |
-                Important: this endpoint is to be implemented by the API consumer.
-                The sample service server will call this endpoint whenever a sample service event occurs.
-                `operationId` value will have to be replaced accordingly with WG API specific semantic
-              operationId: postNotification
-              parameters:
-                - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-              requestBody:
-                required: true
-                content:
-                  application/cloudevents+json:
-                    schema:
-                      $ref: "#/components/schemas/NotificationEvent"
-              responses:
-                "204":
-                  description: Successful notification
-                  headers:
-                    x-correlator:
-                      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-                "400":
-                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
-                "401":
-                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
-                "403":
-                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-                "410":
-                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
-                "429":
-                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
-              security:
-                - {}
-                - notificationsBearerAuth: []
-
-      responses:
-        "201":
-          description: Created
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subscription"
-        "202":
-          description: Request accepted to be processed. It applies for async creation process.
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAsync"
-        "400":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionBadRequest400"
-        "401":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
-        "403":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionPermissionDenied403"
-        "409":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic409"
-        "422":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionUnprocessableEntity422"
-        "429":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
-    get:
-      tags:
-        - Sample Service Subscription
-      summary: "Retrieve a list of sample service event subscriptions"
-      description: Retrieve a list of sample service event subscriptions
-      operationId: retrieveSampleServiceSubscriptionList
-      parameters:
-        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-      security:
-        - openId:
-            - sample-service-subscriptions:read
-      responses:
-        "200":
-          description: List of event subscription details
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                type: array
-                minItems: 0
-                maxItems: 1000
-                items:
-                  $ref: "#/components/schemas/Subscription"
-        "400":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
-        "401":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
-        "403":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-  /subscriptions/{subscriptionId}:
-    get:
-      tags:
-        - Sample Service Subscription
-      summary: "Retrieve a sample service event subscription"
-      description: Retrieve sample service subscription information for a given subscription.
-      operationId: retrieveSampleServiceSubscription
-      security:
-        - openId:
-            - sample-service-subscriptions:read
-      parameters:
-        - $ref: "#/components/parameters/SubscriptionId"
-        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-      responses:
-        "200":
-          description: OK
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subscription"
-        "400":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionIdRequired400"
-        "401":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
-        "403":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-        "404":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-    delete:
-      tags:
-        - Sample Service Subscription
-      summary: "Delete a sample service event subscription"
-      operationId: deleteSampleServiceSubscription
-      description: Delete a given sample service subscription.
-      security:
-        - openId:
-            - sample-service-subscriptions:delete
-      parameters:
-        - $ref: "#/components/parameters/SubscriptionId"
-        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
-      responses:
-        "204":
-          description: Sample service subscription deleted
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-        "202":
-          description: Request accepted to be processed. It applies for async deletion process.
-          headers:
-            x-correlator:
-              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubscriptionAsync"
-        "400":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionIdRequired400"
-        "401":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
-        "403":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
-        "404":
-          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
-
 components:
   securitySchemes:
     openId:
-      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
-    notificationsBearerAuth:
-      $ref: "../common/CAMARA_event_common.yaml#/components/securitySchemes/notificationsBearerAuth"
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect authentication via discovery metadata.
+
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
+
+    x-total-count:
+      description: Total number of items. Mirrors `pagination.totalCount` in the response body.
+      required: false
+      schema:
+        $ref: "#/components/schemas/TotalCount"
+
+    x-total-pages:
+      description: Total number of pages. Mirrors `pagination.totalPages` in the response body.
+      required: false
+      schema:
+        $ref: "#/components/schemas/TotalPages"
+
+    link:
+      description: |
+        Navigation links for paginated results following
+        [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288).
+        Includes only the rels applicable to the current position
+        (`first`, `prev`, `next`, `last`). All original query parameters
+        are preserved in Link URLs.
+        Example:
+          Link: <https://api.example.com/v1/resources?page=1&perPage=20>; rel="first",
+                <https://api.example.com/v1/resources?page=2&perPage=20>; rel="prev",
+                <https://api.example.com/v1/resources?page=4&perPage=20>; rel="next",
+                <https://api.example.com/v1/resources?page=5&perPage=20>; rel="last"
+      required: false
+      schema:
+        type: string
+        maxLength: 8192
 
   parameters:
-    SubscriptionId:
-      name: subscriptionId
-      in: path
-      description: Subscription identifier that was obtained from the create event subscription operation
-      required: true
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
       schema:
-        $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
+        $ref: "#/components/schemas/XCorrelator"
+
+    page:
+      name: page
+      in: query
+      description: >
+        Requested page number. Pages are 1-indexed.
+        Values below 1 are rejected with `400 INVALID_ARGUMENT`.
+      required: false
+      schema:
+        $ref: "#/components/schemas/Page"
+
+    perPage:
+      name: perPage
+      in: query
+      description: >
+        Number of subscriptions to return per page.
+        Values outside the allowed range are rejected with `400 INVALID_ARGUMENT`.
+      required: false
+      schema:
+        $ref: "#/components/schemas/PerPage"
 
   schemas:
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Subscription management (API-specific due to ApiEventType reference)
-    #
-    # SubscriptionRequest and Subscription reference ApiEventType in their
-    # `types` field, which contains sample-service placeholders. Protocol-specific
-    # request/response schemas extend these via allOf.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    SubscriptionRequest:
-      description: The request for creating a event-type event subscription
+    XCorrelator:
+      type: string
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
+      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
+      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+    DateTime:
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
+    TimePeriod:
       type: object
-      required:
-        - sink
-        - protocol
-        - config
-        - types
+      description: A period of time defined by a start date and an optional end date. If `endDate` is not included, then the period has no ending date.
       properties:
-        protocol:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
-        sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
-        types:
-          description: |
-            Camara Event types eligible to be delivered by this subscription.
-            References ApiEventType (not the full NotificationEvent union) —
-            subscription requests target API-specific events only; lifecycle
-            events are server-initiated and cannot be subscribed to directly.
-            Note: the maximum number of event types per subscription will be decided at API project level.
-          type: array
-          minItems: 1
-          maxItems: 1
-          items:
-            $ref: "#/components/schemas/ApiEventType"
-        config:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
-      discriminator:
-        propertyName: protocol
-        mapping:
-          HTTP: "#/components/schemas/HTTPSubscriptionRequest"
-          # Future protocol support (not yet used in CAMARA):
-          # MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
-          # MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
-          # AMQP: "#/components/schemas/AMQPSubscriptionRequest"
-          # NATS: "#/components/schemas/NATSSubscriptionRequest"
-          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
-
-    Subscription:
-      description: Represents a event-type subscription.
+        startDate:
+          $ref: "#/components/schemas/DateTime"
+        endDate:
+          $ref: "#/components/schemas/DateTime"
+      required:
+        - startDate
+    ErrorInfo:
       type: object
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
       required:
-        - sink
-        - protocol
-        - config
-        - types
-        - id
+        - status
+        - code
+        - message
       properties:
-        protocol:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
-        sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
-        types:
-          description: |
-            Camara Event types eligible to be delivered by this subscription.
-            Note: the maximum number of event types per subscription will be decided at API project level
-          type: array
-          minItems: 1
-          maxItems: 1
-          items:
-            $ref: "#/components/schemas/ApiEventType"
-        config:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
-        id:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
-        startsAt:
-          $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        expiresAt:
-          $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
         status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
           type: string
-          description: |-
-            Current status of the subscription - Management of Subscription State engine is not mandatory for now. Note not all statuses may be considered to be implemented. Details:
-              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but subscription creation process is not finished yet.
-              - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
-              - `INACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
-              - `EXPIRED`: Subscription is ended (no longer active). This status applies when subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED` event.
-              - `DELETED`: Subscription is ended as deleted (no longer active). This status applies when subscription information is kept (i.e. subscription workflow is no longer active but its meta-information is kept).
-          enum:
-            - ACTIVATION_REQUESTED
-            - ACTIVE
-            - EXPIRED
-            - INACTIVE
-            - DELETED
-      discriminator:
-        propertyName: protocol
-        mapping:
-          HTTP: "#/components/schemas/HTTPSubscriptionResponse"
-          # Future protocol support (not yet used in CAMARA):
-          # MQTT3: "#/components/schemas/MQTTSubscriptionResponse"
-          # MQTT5: "#/components/schemas/MQTTSubscriptionResponse"
-          # AMQP: "#/components/schemas/AMQPSubscriptionResponse"
-          # NATS: "#/components/schemas/NATSSubscriptionResponse"
-          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionResponse"
-
-    SubscriptionAsync:
-      description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
+          type: string
+          maxLength: 512
+          description: A human-readable description of what the event represents
+    Device:
+      description: |
+        End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
+            The developer can choose to provide the below specified device identifiers:
+            * `ipv4Address`
+            * `ipv6Address`
+            * `phoneNumber`
+            * `networkAccessIdentifier`
+            NOTE1: the network operator might support only a subset of these options. The API Consumer can provide multiple identifiers to ensure compatibility across different network operators. In this case, the API Provider will use one of the identifiers for the API logic without performing any matching checks among the provided identifiers.
+            NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
       type: object
-      required:
-        - id
       properties:
-        id:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+        networkAccessIdentifier:
+          $ref: "#/components/schemas/NetworkAccessIdentifier"
+        ipv4Address:
+          $ref: "#/components/schemas/DeviceIpv4Address"
+        ipv6Address:
+          $ref: "#/components/schemas/DeviceIpv6Address"
+      minProperties: 1
 
-    # ─────────────────────────────────────────────────────────────────────────
-    # API-specific event type enum (contains sample-service placeholders)
-    # ─────────────────────────────────────────────────────────────────────────
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
 
-    ApiEventType:
+        If the API consumer provides more than one device identifier in their request, and this schema is included in the response definition, the API provider MUST use it to return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
+
+    PhoneNumber:
+      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
+      type: string
+      pattern: '^\+[1-9][0-9]{4,14}$'
+      maxLength: 16
+      example: "+123456789"
+
+    NetworkAccessIdentifier:
+      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
+      type: string
+      maxLength: 2048
+      example: "123456789@example.com"
+
+    DeviceIpv4Address:
+      type: object
+      description: |
+        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
+
+        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
+
+        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
+
+        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
+      properties:
+        publicAddress:
+          $ref: "#/components/schemas/SingleIpv4Address"
+        privateAddress:
+          $ref: "#/components/schemas/SingleIpv4Address"
+        publicPort:
+          $ref: "#/components/schemas/Port"
+      anyOf:
+        - required: [publicAddress, privateAddress]
+        - required: [publicAddress, publicPort]
+      example:
+        publicAddress: "84.125.93.10"
+        publicPort: 59765
+
+    SingleIpv4Address:
+      description: A single IPv4 address with no subnet mask
+      type: string
+      format: ipv4
+      maxLength: 15
+      example: "84.125.93.10"
+
+    Port:
+      description: TCP or UDP port number
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 65535
+
+    DeviceIpv6Address:
+      description: |
+        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
+      type: string
+      format: ipv6
+      maxLength: 45
+      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+
+    Area:
+      description: Base schema for all areas
+      type: object
+      properties:
+        areaType:
+          $ref: "#/components/schemas/AreaType"
+      required:
+        - areaType
+      discriminator:
+        propertyName: areaType
+        mapping:
+          CIRCLE: "#/components/schemas/Circle"
+          POLYGON: "#/components/schemas/Polygon"
+
+    AreaType:
       type: string
       description: |
-        Enum of API-specific event type strings for this API project.
-        The reverse-DNS prefix `org.camaraproject.<api-name>` makes each value
-        globally unique, so two different API groups can independently define
-        identically-named event types without any collision risk.
+        Type of this area.
+        CIRCLE - The area is defined as a circle.
+        POLYGON - The area is defined as a polygon.
       enum:
-        - org.camaraproject.sample-service-subscriptions.v0.event-type1
-        - org.camaraproject.sample-service-subscriptions.v0.event-type2
+        - CIRCLE
+        - POLYGON
 
-    # ─────────────────────────────────────────────────────────────────────────
-    # Subscription lifecycle event group (Commonalities-owned structure,
-    # but event type strings contain sample-service placeholders)
-    #
-    # Common to every CAMARA API that supports subscriptions.
-    # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
-    # and owns the lifecycle discriminator mapping.
-    #
-    # API projects reference this group via NotificationEvent but only update
-    # the sample-service prefix in the event type strings.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    SubscriptionLifecycleEvent:
-      description: |
-        Subscription lifecycle event group, common to all CAMARA APIs that
-        support explicit subscriptions.
-        Extends the CloudEvent envelope and constrains `type` to the set of
-        lifecycle event types managed by Commonalities.
+    Circle:
+      description: Circular area
       allOf:
-        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/Area"
         - type: object
+          required:
+            - center
+            - radius
           properties:
-            type:
-              $ref: "#/components/schemas/SubscriptionLifecycleEventType"
-      discriminator:
-        propertyName: type
-        mapping:
-          org.camaraproject.sample-service-subscriptions.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
-          org.camaraproject.sample-service-subscriptions.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
-          org.camaraproject.sample-service-subscriptions.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
+            center:
+              $ref: "#/components/schemas/Point"
+            radius:
+              type: number
+              description: Distance from the center in meters
+              minimum: 1
 
-    SubscriptionLifecycleEventType:
-      type: string
-      description: |
-        Enum of subscription lifecycle event type strings.
-        These are managed by Commonalities and are identical across all CAMARA
-        APIs that support explicit subscriptions.
-        Kept as a separate named schema so the set of valid lifecycle type
-        strings can be referenced independently from the discriminated schema.
-      enum:
-        - org.camaraproject.sample-service-subscriptions.v0.subscription-started
-        - org.camaraproject.sample-service-subscriptions.v0.subscription-updated
-        - org.camaraproject.sample-service-subscriptions.v0.subscription-ended
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # API-specific notification event group
-    #
-    # Extends CloudEvent via allOf and does exactly two things:
-    #   1. Constrains `type` to its own ApiEventType enum
-    #   2. Owns the discriminator mapping from each enum value to a concrete schema
-    #
-    # Adding a new event type requires only: adding a value to ApiEventType and
-    # adding a discriminator mapping entry here. CloudEvent is never touched.
-
-    ApiNotificationEvent:
-      description: |
-        API-specific notification event group.
-        Extends the CloudEvent envelope and constrains `type` to the set of
-        event types defined by this API project.
-        Adding a new event type only requires updating ApiEventType and the
-        discriminator mapping below — the CloudEvent base never changes.
+    Polygon:
+      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersect itself.
       allOf:
-        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
+        - $ref: "#/components/schemas/Area"
         - type: object
+          required:
+            - boundary
           properties:
-            type:
-              $ref: "#/components/schemas/ApiEventType"
-      discriminator:
-        propertyName: "type"
-        mapping:
-          org.camaraproject.sample-service-subscriptions.v0.event-type1: "#/components/schemas/EventApiSpecific1"
-          org.camaraproject.sample-service-subscriptions.v0.event-type2: "#/components/schemas/EventApiSpecific2"
+            boundary:
+              $ref: "#/components/schemas/PointList"
+
+    PointList:
+      description: List of points defining a polygon
+      type: array
+      items:
+        $ref: "#/components/schemas/Point"
+      minItems: 3
+      maxItems: 15
+
+    Point:
+      type: object
+      description: Coordinates (latitude, longitude) defining a location in a map
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      example:
+        latitude: 50.735851
+        longitude: 7.10066
+
+    Latitude:
+      description: Latitude component of a location
+      type: number
+      format: double
+      minimum: -90
+      maximum: 90
+
+    Longitude:
+      description: Longitude component of location
+      type: number
+      format: double
+      minimum: -180
+      maximum: 180
 
     # ─────────────────────────────────────────────────────────────────────────
-    # Callback union (API project-owned)
-    #
-    # oneOf over all valid event groups at the callback endpoint.
-    # Owns no discriminator and applies no constraints of its own.
-    # Its only job is to enumerate which groups are valid for this API.
-    #
-    # To add a new event group: add it to the oneOf list. That is the only
-    # change required at this layer.
+    # Pagination
     # ─────────────────────────────────────────────────────────────────────────
 
-    NotificationEvent:
-      description: |
-        Union of all valid notification event groups at the callback endpoint.
-        This schema owns no discriminator — routing within each group is
-        handled by ApiNotificationEvent and SubscriptionLifecycleEvent
-        respectively. Its only responsibility is to enumerate which groups
-        are valid payloads for this API's notification callback.
-      oneOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+    Pagination:
+      description: Pagination details helping to navigate through paged results efficiently.
+      type: object
+      properties:
+        page:
+          $ref: "#/components/schemas/Page"
+        perPage:
+          $ref: "#/components/schemas/PerPage"
+        totalCount:
+          $ref: "#/components/schemas/TotalCount"
+        totalPages:
+          $ref: "#/components/schemas/TotalPages"
 
-    # ─────────────────────────────────────────────────────────────────────────
-    # Concrete event schemas — API-specific (API project-owned)
-    # ─────────────────────────────────────────────────────────────────────────
+    Page:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 2147483647
+      description: Current page number (1-indexed).
+      example: 1
+    PerPage:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 100
+      description: Number of items per page.
+      example: 20
+    TotalCount:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 2147483647
+      description: Total number of items matching the query, after filters applied. MAY be omitted where a full count query is prohibitively expensive.
+      example: 87
+    TotalPages:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 2147483647
+      description: Total number of pages. Equals ceil(totalCount / perPage). MAY be omitted where totalCount is omitted.
+      example: 5
 
-    EventApiSpecific1:
-      description: event structure for event-type event 1
-      allOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - type: object
-          properties:
-            data:
-              type: object
+
+  responses:
+    #######################################################
+    #######################################################
+    # ERROR RESPONSE SCHEMA TEMPLATE
+    #   - Objective: Make normative error `status` and `code` values
+    #   - Schema Template rationale:
+    #     - The `allOf` in content.application/json.schema allows a combination of both the generic ErrorInfo schema and the specific schema for this error response,
+    #       which validates that `status` and `code` have only the specified values.
+    #       This `allOf` is used without discriminator because it does not imply any hierarchy between the models, just 2 schemas that must be independently validated.
+    #######################################################
+    #    ErrorResponseSchema:
+    #      ...
+    #      content:
+    #        application/json:
+    #          schema:
+    #            allOf:
+    #              - $ref: '#/components/schemas/ErrorInfo'
+    #              - type: object
+    #                properties:
+    #                  status:
+    #                    enum:
+    #                      - <status>
+    #                  code:
+    #                    enum:
+    #                      - <code1>
+    #                      - <code2>
+    #          examples:
+    #            ExampleKey1:
+    #              value:
+    #                status: <status>
+    #                code: <code1>
+    #                message: <message1>
+    #            ExampleKey2:
+    #              value:
+    #                status: <status>
+    #                code: <code2>
+    #                message: <message2>
+    #######################################################
+    #######################################################
+    Generic400:
+      description: Bad Request
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
+                # GENERIC_400_{{SPECIFIC_CODE}}:
+                #   description: Specific Syntax Exception regarding a field that is relevant in the context of the API
+                #   value:
+                #     status: 400
+                #     code: "{{SPECIFIC_CODE}}"
+                #     message: Message for specific code
+    Generic401:
+      description: Unauthorized
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 401
+                  code:
+                    enum:
+                      - UNAUTHENTICATED
+          examples:
+            GENERIC_401_UNAUTHENTICATED:
+              description: Request cannot be authenticated and a new authentication is required
+              value:
+                status: 401
+                code: UNAUTHENTICATED
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+    Generic403:
+      description: Forbidden
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+                      - INVALID_TOKEN_CONTEXT
+                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
+            GENERIC_403_INVALID_TOKEN_CONTEXT:
+              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
+              value:
+                status: 403
+                code: INVALID_TOKEN_CONTEXT
+                # message: "{{field}} is not consistent with access token."
+                message: "Request body is not consistent with access token."
+                # GENERIC_403_{{SPECIFIC_CODE}}:
+                #   description: Indicate a Business Logic condition that forbids a process not attached to a specific field in the context of the API
+                #   value:
+                #     status: 403
+                #     code: "{{SPECIFIC_CODE}}"
+                #     message: Message for specific code
+    Generic404:
+      description: Not found
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 404
+                  code:
+                    enum:
+                      - NOT_FOUND
+                      - IDENTIFIER_NOT_FOUND
+                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
+          examples:
+            GENERIC_404_NOT_FOUND:
+              description: Resource is not found
+              value:
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found.
+            GENERIC_404_IDENTIFIER_NOT_FOUND:
+              description: Some identifier cannot be matched to a device
+              value:
+                status: 404
+                code: IDENTIFIER_NOT_FOUND
+                message: Device identifier not found.
+                # GENERIC_404_{{SPECIFIC_CODE}}:
+                #   description: Specific situation to highlight the resource/concept not found
+                #   value:
+                #     status: 404
+                #     code: "{{SPECIFIC_CODE}}"
+                #     message: Message for specific code
+    Generic405:
+      description: Method Not Allowed
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 405
+                  code:
+                    enum:
+                      - METHOD_NOT_ALLOWED
+          examples:
+            GENERIC_405_METHOD_NOT_ALLOWED:
+              description: Invalid HTTP verb used with a given endpoint
+              value:
+                status: 405
+                code: METHOD_NOT_ALLOWED
+                message: The requested method is not allowed/supported on the target resource.
+    Generic406:
+      description: Not Acceptable
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 406
+                  code:
+                    enum:
+                      - NOT_ACCEPTABLE
+          examples:
+            GENERIC_406_NOT_ACCEPTABLE:
+              description: API Server does not accept the media type (`Accept-*` header) indicated by API client
+              value:
+                status: 406
+                code: NOT_ACCEPTABLE
+                message: The server cannot produce a response matching the content requested by the client through `Accept-*` headers.
+    Generic409:
+      description: Conflict
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 409
+                  code:
+                    enum:
+                      - ABORTED
+                      - ALREADY_EXISTS
+                      - CONFLICT
+                      - INCOMPATIBLE_STATE
+                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
+          examples:
+            GENERIC_409_ABORTED:
+              description: The resource is undergoing modification by another process
+              value:
+                status: 409
+                code: ABORTED
+                message: Resource is being modified by another operation. Please wait, and retry if appropriate.
+            GENERIC_409_ALREADY_EXISTS:
+              description: Trying to create an existing resource
+              value:
+                status: 409
+                code: ALREADY_EXISTS
+                message: The resource that a client tried to create already exists.
+            GENERIC_409_CONFLICT:
+              ###################################
+              # This Error Code is DEPRECATED
+              ###################################
+              description: Duplication of an existing resource
+              value:
+                status: 409
+                code: CONFLICT
+                message: A specified resource duplicate entry found.
+            GENERIC_409_INCOMPATIBLE_STATE:
               description: |
-                Event-specific payload for event-type1.
-                Replace with the actual data schema for this event type.
-
-    EventApiSpecific2:
-      description: event structure for event-type event 2
-      allOf:
-        - $ref: "#/components/schemas/ApiNotificationEvent"
-        - type: object
-          properties:
-            data:
-              type: object
-              description: |
-                Event-specific payload for event-type2.
-                Replace with the actual data schema for this event type.
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Concrete event schemas — Subscription lifecycle (Commonalities-owned)
-    # Data payloads are referenced from CAMARA_event_common.yaml.
-    # ─────────────────────────────────────────────────────────────────────────
-
-    EventSubscriptionStarted:
-      description: event structure for event subscription started
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionStarted"
-
-    EventSubscriptionUpdated:
-      description: event structure for event subscription updated
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionUpdated"
-
-    EventSubscriptionEnded:
-      description: event structure for event subscription ended
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionEnded"
-
-    # ─────────────────────────────────────────────────────────────────────────
-    # Protocol-specific subscription schemas
-    # Protocol settings are referenced from CAMARA_event_common.yaml.
-    #
-    # Future protocol support (not yet used in CAMARA):
-    # MQTTSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
-    # MQTTSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
-    # AMQPSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
-    # AMQPSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
-    # ApacheKafkaSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
-    # ApacheKafkaSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
-    # NATSSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
-    # NATSSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
-    # ─────────────────────────────────────────────────────────────────────────
-
-    HTTPSubscriptionRequest:
-      description: Subscription request for HTTP-based event delivery.
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionRequest"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
-
-    HTTPSubscriptionResponse:
-      description: Subscription resource returned for HTTP-based event delivery.
-      allOf:
-        - $ref: "#/components/schemas/Subscription"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
+                The status of the referenced resource is not compatible.
+              value:
+                status: 409
+                code: INCOMPATIBLE_STATE
+                message: Resource must be in AVAILABLE state to extend. Current state is UNAVAILABLE.
+                # GENERIC_409_{{SPECIFIC_CODE}}:
+                #   description: Specific conflict situation that is relevant in the context of the API
+                #   value:
+                #     status: 409
+                #     code: "{{SPECIFIC_CODE}}"
+                #     message: Message for specific code
+    Generic410:
+      description: Gone
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 410
+                  code:
+                    enum:
+                      - GONE
+          examples:
+            GENERIC_410_GONE:
+              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
+              value:
+                status: 410
+                code: GONE
+                message: Access to the target resource is no longer available.
+    Generic412:
+      description: Failed precondition
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 412
+                  code:
+                    enum:
+                      - FAILED_PRECONDITION
+          examples:
+            GENERIC_412_FAILED_PRECONDITION:
+              description: Indication by the API Server that the request cannot be processed in current system state
+              value:
+                status: 412
+                code: FAILED_PRECONDITION
+                message: Request cannot be executed in the current system state.
+    Generic415:
+      description: Unsupported Media Type
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 415
+                  code:
+                    enum:
+                      - UNSUPPORTED_MEDIA_TYPE
+          examples:
+            GENERIC_415_UNSUPPORTED_MEDIA_TYPE:
+              description: Payload format of the request is in an unsupported format by the Server. Should not happen
+              value:
+                status: 415
+                code: UNSUPPORTED_MEDIA_TYPE
+                message: The server refuses to accept the request because the payload format is in an unsupported format.
+    Generic422:
+      description: Unprocessable Content
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
+                # GENERIC_422_{{SPECIFIC_CODE}}:
+                #   description: Any semantic condition associated to business logic, specifically related to a field or data structure
+                #   value:
+                #     status: 422
+                #     code: "{{SPECIFIC_CODE}}"
+                #     message: Message for specific code
+    Generic429:
+      description: Too Many Requests
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 429
+                  code:
+                    enum:
+                      - QUOTA_EXCEEDED
+                      - TOO_MANY_REQUESTS
+          examples:
+            GENERIC_429_QUOTA_EXCEEDED:
+              description: Request is rejected due to exceeding a business quota limit
+              value:
+                status: 429
+                code: QUOTA_EXCEEDED
+                message: Out of resource quota.
+            GENERIC_429_TOO_MANY_REQUESTS:
+              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
+              value:
+                status: 429
+                code: TOO_MANY_REQUESTS
+                message: Rate limit reached.
+    Generic500:
+      description: Internal Server Error
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 500
+                  code:
+                    enum:
+                      - INTERNAL
+          examples:
+            GENERIC_500_INTERNAL:
+              description: Problem in Server side. Regular Server Exception
+              value:
+                status: 500
+                code: INTERNAL
+                message: Unknown server error. Typically a server bug.
+    Generic501:
+      description: Not Implemented
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 501
+                  code:
+                    enum:
+                      - NOT_IMPLEMENTED
+          examples:
+            GENERIC_501_NOT_IMPLEMENTED:
+              description: Service not implemented. The use of this code should be avoided as far as possible to get the objective to reach aligned implementations
+              value:
+                status: 501
+                code: NOT_IMPLEMENTED
+                message: This functionality is not implemented yet.
+    Generic502:
+      description: Bad Gateway
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 502
+                  code:
+                    enum:
+                      - BAD_GATEWAY
+          examples:
+            GENERIC_502_BAD_GATEWAY:
+              description: Internal routing problem in the Server side that blocks to manage the service properly
+              value:
+                status: 502
+                code: BAD_GATEWAY
+                message: An upstream internal service cannot be reached.
+    Generic503:
+      description: Service Unavailable
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 503
+                  code:
+                    enum:
+                      - UNAVAILABLE
+          examples:
+            GENERIC_503_UNAVAILABLE:
+              description: Service is not available. Temporary situation usually related to maintenance process in the server side
+              value:
+                status: 503
+                code: UNAVAILABLE
+                message: Service Unavailable.
+    Generic504:
+      description: Gateway Timeout
+      headers:
+        x-correlator:
+          $ref: "#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 504
+                  code:
+                    enum:
+                      - TIMEOUT
+          examples:
+            GENERIC_504_TIMEOUT:
+              description: API Server Timeout
+              value:
+                status: 504
+                code: TIMEOUT
+                message: Request timeout exceeded.

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -1,931 +1,633 @@
+# NOTE: This is a template. Replace all occurrences of "sample-service-subscriptions"
+# (and its Title Case variant) with the actual API name in the appropriate casing.
+openapi: 3.0.3
 info:
-  title: CAMARA common data types
+  title: Sample Service Subscription Template
   description: |
-    Common data types for CAMARA APIs.
-    This file contains Commonalities-owned schemas that are identical across all
-    CAMARA APIs, including error responses, common parameters, headers, and
-    reusable data types.
+    This file is a template for CAMARA API explicit subscription endpoint and for Notification model.
+    Additional information are provided in [CAMARA API Event Subscription and Notification Guide](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md).
 
-    API repositories place this file in `code/common/` and reference schemas
-    via `$ref: "../common/CAMARA_common.yaml#/components/schemas/<SchemaName>"`.
+    Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<event-version>.<event-name>``
+
+    Note on ``security`` - ``openId`` scope: The scope values must be replaced accordingly to the format defined in the guideline document.
+
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
   x-camara-commonalities: 0.7.0
 
+externalDocs:
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/apiRepository
+  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
+servers:
+  - url: "{apiRoot}/sample-service-subscriptions/vwip"
+    variables:
+      apiRoot:
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+tags:
+  - name: Sample Service Subscription
+    description: Operations to manage event subscriptions on event-type event
+
+paths:
+  /subscriptions:
+    post:
+      tags:
+        - Sample Service Subscription
+      summary: "Create a sample service event subscription"
+      description: Create a sample service event subscription
+      operationId: createSampleServiceSubscription
+      parameters:
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+      security:
+        - openId:
+            - sample-service-subscriptions:event-type1:grant-level
+            - sample-service-subscriptions:event-type2:grant-level
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionRequest"
+        required: true
+      callbacks:
+        notifications:
+          "{$request.body#/sink}":
+            post:
+              summary: "notifications callback"
+              description: |
+                Important: this endpoint is to be implemented by the API consumer.
+                The sample service server will call this endpoint whenever a sample service event occurs.
+                `operationId` value will have to be replaced accordingly with WG API specific semantic
+              operationId: postNotification
+              parameters:
+                - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+              requestBody:
+                required: true
+                content:
+                  application/cloudevents+json:
+                    schema:
+                      $ref: "#/components/schemas/NotificationEvent"
+              responses:
+                "204":
+                  description: Successful notification
+                  headers:
+                    x-correlator:
+                      $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+                "400":
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
+                "401":
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+                "403":
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+                "410":
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic410"
+                "429":
+                  $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
+              security:
+                - {}
+                - notificationsBearerAuth: []
+
+      responses:
+        "201":
+          description: Created
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subscription"
+        "202":
+          description: Request accepted to be processed. It applies for async creation process.
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionAsync"
+        "400":
+          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionBadRequest400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionPermissionDenied403"
+        "409":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic409"
+        "422":
+          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionUnprocessableEntity422"
+        "429":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
+    get:
+      tags:
+        - Sample Service Subscription
+      summary: "Retrieve a list of sample service event subscriptions"
+      description: Retrieve a list of sample service event subscriptions
+      operationId: retrieveSampleServiceSubscriptionList
+      parameters:
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/page"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/perPage"
+      security:
+        - openId:
+            - sample-service-subscriptions:read
+      responses:
+        "200":
+          description: List of event subscription details
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+            X-Total-Count:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-total-count"
+            X-Total-Pages:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-total-pages"
+            Link:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/link"
+
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionList"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+  /subscriptions/{subscriptionId}:
+    get:
+      tags:
+        - Sample Service Subscription
+      summary: "Retrieve a sample service event subscription"
+      description: Retrieve sample service subscription information for a given subscription.
+      operationId: retrieveSampleServiceSubscription
+      security:
+        - openId:
+            - sample-service-subscriptions:read
+      parameters:
+        - $ref: "#/components/parameters/SubscriptionId"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+      responses:
+        "200":
+          description: OK
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subscription"
+        "400":
+          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionIdRequired400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+        "404":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+    delete:
+      tags:
+        - Sample Service Subscription
+      summary: "Delete a sample service event subscription"
+      operationId: deleteSampleServiceSubscription
+      description: Delete a given sample service subscription.
+      security:
+        - openId:
+            - sample-service-subscriptions:delete
+      parameters:
+        - $ref: "#/components/parameters/SubscriptionId"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+      responses:
+        "204":
+          description: Sample service subscription deleted
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+        "202":
+          description: Request accepted to be processed. It applies for async deletion process.
+          headers:
+            x-correlator:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionAsync"
+        "400":
+          $ref: "../common/CAMARA_event_common.yaml#/components/responses/SubscriptionIdRequired400"
+        "401":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
+        "403":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic403"
+        "404":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
+
 components:
   securitySchemes:
     openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.com/.well-known/openid-configuration
-      description: OpenID Connect authentication via discovery metadata.
-
-  headers:
-    x-correlator:
-      description: Correlation id for the different services
-      schema:
-        $ref: "#/components/schemas/XCorrelator"
-
-    x-total-count:
-      description: Total number of items. Mirrors `pagination.totalCount` in the response body.
-      required: false
-      schema:
-        $ref: "#/components/schemas/TotalCount"
-
-    x-total-pages:
-      description: Total number of pages. Mirrors `pagination.totalPages` in the response body.
-      required: false
-      schema:
-        $ref: "#/components/schemas/TotalPages"
-
-    link:
-      description: |
-        Navigation links for paginated results following
-        [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288).
-        Includes only the rels applicable to the current position
-        (`first`, `prev`, `next`, `last`). All original query parameters
-        are preserved in Link URLs.
-        Example:
-          Link: <https://api.example.com/v1/resources?page=1&perPage=20>; rel="first",
-                <https://api.example.com/v1/resources?page=2&perPage=20>; rel="prev",
-                <https://api.example.com/v1/resources?page=4&perPage=20>; rel="next",
-                <https://api.example.com/v1/resources?page=5&perPage=20>; rel="last"
-      required: false
-      schema:
-        type: string
-        maxLength: 8192
+      $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
+    notificationsBearerAuth:
+      $ref: "../common/CAMARA_event_common.yaml#/components/securitySchemes/notificationsBearerAuth"
 
   parameters:
-    x-correlator:
-      name: x-correlator
-      in: header
-      description: Correlation id for the different services
+    SubscriptionId:
+      name: subscriptionId
+      in: path
+      description: Subscription identifier that was obtained from the create event subscription operation
+      required: true
       schema:
-        $ref: "#/components/schemas/XCorrelator"
-
-    page:
-      name: page
-      in: query
-      description: >
-        Requested page number. Pages are 1-indexed.
-        Values below 1 are rejected with `400 INVALID_ARGUMENT`.
-      required: false
-      schema:
-        $ref: "#/components/schemas/Page"
-
-    perPage:
-      name: perPage
-      in: query
-      description: >
-        Number of subscriptions to return per page.
-        Values outside the allowed range are rejected with `400 INVALID_ARGUMENT`.
-      required: false
-      schema:
-        $ref: "#/components/schemas/PerPage"
+        $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
 
   schemas:
-    XCorrelator:
-      type: string
-      description: Correlator string, UUID format recommended but any string matching the pattern can be used
-      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
-      maxLength: 256
-      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
-    DateTime:
-      type: string
-      format: date-time
-      maxLength: 64
-      description: Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      example: "2018-04-05T17:31:00Z"
-    TimePeriod:
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Subscription management (API-specific due to ApiEventType reference)
+    #
+    # SubscriptionRequest and Subscription reference ApiEventType in their
+    # `types` field, which contains sample-service placeholders. Protocol-specific
+    # request/response schemas extend these via allOf.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionRequest:
+      description: The request for creating a event-type event subscription
       type: object
-      description: A period of time defined by a start date and an optional end date. If `endDate` is not included, then the period has no ending date.
-      properties:
-        startDate:
-          $ref: "#/components/schemas/DateTime"
-        endDate:
-          $ref: "#/components/schemas/DateTime"
       required:
-        - startDate
-    ErrorInfo:
-      type: object
-      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
-      required:
-        - status
-        - code
-        - message
+        - sink
+        - protocol
+        - config
+        - types
       properties:
-        status:
-          type: integer
-          format: int32
-          minimum: 100
-          maximum: 599
-          description: HTTP response status code
-        code:
+        protocol:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
+        sink:
           type: string
-          maxLength: 96
-          description: A human-readable code to describe the error
-        message:
-          type: string
-          maxLength: 512
-          description: A human-readable description of what the event represents
-    Device:
-      description: |
-        End-user equipment able to connect to a mobile network. Examples of devices include smartphones or IoT sensors/actuators.
-            The developer can choose to provide the below specified device identifiers:
-            * `ipv4Address`
-            * `ipv6Address`
-            * `phoneNumber`
-            * `networkAccessIdentifier`
-            NOTE1: the network operator might support only a subset of these options. The API Consumer can provide multiple identifiers to ensure compatibility across different network operators. In this case, the API Provider will use one of the identifiers for the API logic without performing any matching checks among the provided identifiers.
-            NOTE2: as for this Commonalities release, we are enforcing that the networkAccessIdentifier is only part of the schema for future-proofing, and CAMARA does not currently allow its use. After the CAMARA meta-release work is concluded and the relevant issues are resolved, its use will need to be explicitly documented in the guidelines.
-      type: object
-      properties:
-        phoneNumber:
-          $ref: "#/components/schemas/PhoneNumber"
-        networkAccessIdentifier:
-          $ref: "#/components/schemas/NetworkAccessIdentifier"
-        ipv4Address:
-          $ref: "#/components/schemas/DeviceIpv4Address"
-        ipv6Address:
-          $ref: "#/components/schemas/DeviceIpv6Address"
-      minProperties: 1
-
-    DeviceResponse:
-      description: |
-        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
-
-        If the API consumer provides more than one device identifier in their request, and this schema is included in the response definition, the API provider MUST use it to return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
-
-      allOf:
-        - $ref: "#/components/schemas/Device"
-        - maxProperties: 1
-
-    PhoneNumber:
-      description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
-      type: string
-      pattern: '^\+[1-9][0-9]{4,14}$'
-      maxLength: 16
-      example: "+123456789"
-
-    NetworkAccessIdentifier:
-      description: A public identifier addressing a subscription in a mobile network. In 3GPP terminology, it corresponds to the GPSI formatted with the External Identifier ({Local Identifier}@{Domain Identifier}). Unlike the telephone number, the network access identifier is not subjected to portability ruling in force, and is individually managed by each operator.
-      type: string
-      maxLength: 2048
-      example: "123456789@example.com"
-
-    DeviceIpv4Address:
-      type: object
-      description: |
-        The device should be identified by either the public (observed) IP address and port as seen by the application server, or the private (local) and any public (observed) IP addresses in use by the device (this information can be obtained by various means, for example from some DNS servers).
-
-        If the allocated and observed IP addresses are the same (i.e. NAT is not in use) then  the same address should be specified for both publicAddress and privateAddress.
-
-        If NAT64 is in use, the device should be identified by its publicAddress and publicPort, or separately by its allocated IPv6 address (field ipv6Address of the Device object)
-
-        In all cases, publicAddress must be specified, along with at least one of either privateAddress or publicPort, dependent upon which is known. In general, mobile devices cannot be identified by their public IPv4 address alone.
-      properties:
-        publicAddress:
-          $ref: "#/components/schemas/SingleIpv4Address"
-        privateAddress:
-          $ref: "#/components/schemas/SingleIpv4Address"
-        publicPort:
-          $ref: "#/components/schemas/Port"
-      anyOf:
-        - required: [publicAddress, privateAddress]
-        - required: [publicAddress, publicPort]
-      example:
-        publicAddress: "84.125.93.10"
-        publicPort: 59765
-
-    SingleIpv4Address:
-      description: A single IPv4 address with no subnet mask
-      type: string
-      format: ipv4
-      maxLength: 15
-      example: "84.125.93.10"
-
-    Port:
-      description: TCP or UDP port number
-      type: integer
-      format: int32
-      minimum: 1
-      maximum: 65535
-
-    DeviceIpv6Address:
-      description: |
-        The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
-      type: string
-      format: ipv6
-      maxLength: 45
-      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
-
-    Area:
-      description: Base schema for all areas
-      type: object
-      properties:
-        areaType:
-          $ref: "#/components/schemas/AreaType"
-      required:
-        - areaType
+          format: uri
+          maxLength: 2048
+          pattern: ^https:\/\/.+$
+          description: The address to which events shall be delivered using the selected protocol.
+          example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
+        types:
+          description: |
+            Camara Event types eligible to be delivered by this subscription.
+            References ApiEventType (not the full NotificationEvent union) —
+            subscription requests target API-specific events only; lifecycle
+            events are server-initiated and cannot be subscribed to directly.
+            Note: the maximum number of event types per subscription will be decided at API project level.
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            $ref: "#/components/schemas/ApiEventType"
+        config:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
       discriminator:
-        propertyName: areaType
+        propertyName: protocol
         mapping:
-          CIRCLE: "#/components/schemas/Circle"
-          POLYGON: "#/components/schemas/Polygon"
+          HTTP: "#/components/schemas/HTTPSubscriptionRequest"
+          # Future protocol support (not yet used in CAMARA):
+          # MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
+          # MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
+          # AMQP: "#/components/schemas/AMQPSubscriptionRequest"
+          # NATS: "#/components/schemas/NATSSubscriptionRequest"
+          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
 
-    AreaType:
+    Subscription:
+      description: Represents a event-type subscription.
+      type: object
+      required:
+        - sink
+        - protocol
+        - config
+        - types
+        - id
+      properties:
+        protocol:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
+        sink:
+          type: string
+          format: uri
+          maxLength: 2048
+          pattern: ^https:\/\/.+$
+          description: The address to which events shall be delivered using the selected protocol.
+          example: "https://endpoint.example.com/sink"
+        types:
+          description: |
+            Camara Event types eligible to be delivered by this subscription.
+            Note: the maximum number of event types per subscription will be decided at API project level
+          type: array
+          minItems: 1
+          maxItems: 1
+          items:
+            $ref: "#/components/schemas/ApiEventType"
+        config:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
+        id:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
+        startsAt:
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+        expiresAt:
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+        status:
+          type: string
+          description: |-
+            Current status of the subscription - Management of Subscription State engine is not mandatory for now. Note not all statuses may be considered to be implemented. Details:
+              - `ACTIVATION_REQUESTED`: Subscription creation (POST) is triggered but subscription creation process is not finished yet.
+              - `ACTIVE`: Subscription creation process is completed. Subscription is fully operative.
+              - `INACTIVE`: Subscription is temporarily inactive, but its workflow logic is not deleted.
+              - `EXPIRED`: Subscription is ended (no longer active). This status applies when subscription is ended due to `SUBSCRIPTION_EXPIRED` or `ACCESS_TOKEN_EXPIRED` event.
+              - `DELETED`: Subscription is ended as deleted (no longer active). This status applies when subscription information is kept (i.e. subscription workflow is no longer active but its meta-information is kept).
+          enum:
+            - ACTIVATION_REQUESTED
+            - ACTIVE
+            - EXPIRED
+            - INACTIVE
+            - DELETED
+      discriminator:
+        propertyName: protocol
+        mapping:
+          HTTP: "#/components/schemas/HTTPSubscriptionResponse"
+          # Future protocol support (not yet used in CAMARA):
+          # MQTT3: "#/components/schemas/MQTTSubscriptionResponse"
+          # MQTT5: "#/components/schemas/MQTTSubscriptionResponse"
+          # AMQP: "#/components/schemas/AMQPSubscriptionResponse"
+          # NATS: "#/components/schemas/NATSSubscriptionResponse"
+          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionResponse"
+
+    SubscriptionAsync:
+      description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
+
+    SubscriptionList:
+      description: Response with subscriptions list
+      type: object
+      required:
+        - subscriptions
+      properties:
+        subscriptions:
+          description: Subscriptions list
+          type: array
+          minItems: 0
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/Subscription"
+        pagination:
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/Pagination"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # API-specific event type enum (contains sample-service placeholders)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    ApiEventType:
       type: string
       description: |
-        Type of this area.
-        CIRCLE - The area is defined as a circle.
-        POLYGON - The area is defined as a polygon.
+        Enum of API-specific event type strings for this API project.
+        The reverse-DNS prefix `org.camaraproject.<api-name>` makes each value
+        globally unique, so two different API groups can independently define
+        identically-named event types without any collision risk.
       enum:
-        - CIRCLE
-        - POLYGON
-
-    Circle:
-      description: Circular area
-      allOf:
-        - $ref: "#/components/schemas/Area"
-        - type: object
-          required:
-            - center
-            - radius
-          properties:
-            center:
-              $ref: "#/components/schemas/Point"
-            radius:
-              type: number
-              description: Distance from the center in meters
-              minimum: 1
-
-    Polygon:
-      description: Polygonal area. The Polygon should be a simple polygon, i.e. should not intersect itself.
-      allOf:
-        - $ref: "#/components/schemas/Area"
-        - type: object
-          required:
-            - boundary
-          properties:
-            boundary:
-              $ref: "#/components/schemas/PointList"
-
-    PointList:
-      description: List of points defining a polygon
-      type: array
-      items:
-        $ref: "#/components/schemas/Point"
-      minItems: 3
-      maxItems: 15
-
-    Point:
-      type: object
-      description: Coordinates (latitude, longitude) defining a location in a map
-      required:
-        - latitude
-        - longitude
-      properties:
-        latitude:
-          $ref: "#/components/schemas/Latitude"
-        longitude:
-          $ref: "#/components/schemas/Longitude"
-      example:
-        latitude: 50.735851
-        longitude: 7.10066
-
-    Latitude:
-      description: Latitude component of a location
-      type: number
-      format: double
-      minimum: -90
-      maximum: 90
-
-    Longitude:
-      description: Longitude component of location
-      type: number
-      format: double
-      minimum: -180
-      maximum: 180
+        - org.camaraproject.sample-service-subscriptions.v0.event-type1
+        - org.camaraproject.sample-service-subscriptions.v0.event-type2
 
     # ─────────────────────────────────────────────────────────────────────────
-    # Pagination
+    # Subscription lifecycle event group (Commonalities-owned structure,
+    # but event type strings contain sample-service placeholders)
+    #
+    # Common to every CAMARA API that supports subscriptions.
+    # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
+    # and owns the lifecycle discriminator mapping.
+    #
+    # API projects reference this group via NotificationEvent but only update
+    # the sample-service prefix in the event type strings.
     # ─────────────────────────────────────────────────────────────────────────
 
-    Pagination:
-      description: Pagination details helping to navigate through paged results efficiently.
-      type: object
-      properties:
-        page:
-          $ref: "#/components/schemas/Page"
-        perPage:
-          $ref: "#/components/schemas/PerPage"
-        totalCount:
-          $ref: "#/components/schemas/TotalCount"
-        totalPages:
-          $ref: "#/components/schemas/TotalPages"
+    SubscriptionLifecycleEvent:
+      description: |
+        Subscription lifecycle event group, common to all CAMARA APIs that
+        support explicit subscriptions.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        lifecycle event types managed by Commonalities.
+      allOf:
+        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/SubscriptionLifecycleEventType"
+      discriminator:
+        propertyName: type
+        mapping:
+          org.camaraproject.sample-service-subscriptions.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
+          org.camaraproject.sample-service-subscriptions.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
+          org.camaraproject.sample-service-subscriptions.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
 
-    Page:
-      type: integer
-      format: int32
-      minimum: 1
-      maximum: 2147483647
-      description: Current page number (1-indexed).
-      example: 1
-    PerPage:
-      type: integer
-      format: int32
-      minimum: 1
-      maximum: 100
-      description: Number of items per page.
-      example: 20
-    TotalCount:
-      type: integer
-      format: int32
-      minimum: 0
-      maximum: 2147483647
-      description: Total number of items matching the query, after filters applied. MAY be omitted where a full count query is prohibitively expensive.
-      example: 87
-    TotalPages:
-      type: integer
-      format: int32
-      minimum: 0
-      maximum: 2147483647
-      description: Total number of pages. Equals ceil(totalCount / perPage). MAY be omitted where totalCount is omitted.
-      example: 5
+    SubscriptionLifecycleEventType:
+      type: string
+      description: |
+        Enum of subscription lifecycle event type strings.
+        These are managed by Commonalities and are identical across all CAMARA
+        APIs that support explicit subscriptions.
+        Kept as a separate named schema so the set of valid lifecycle type
+        strings can be referenced independently from the discriminated schema.
+      enum:
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-started
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-updated
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-ended
 
+    # ─────────────────────────────────────────────────────────────────────────
+    # API-specific notification event group
+    #
+    # Extends CloudEvent via allOf and does exactly two things:
+    #   1. Constrains `type` to its own ApiEventType enum
+    #   2. Owns the discriminator mapping from each enum value to a concrete schema
+    #
+    # Adding a new event type requires only: adding a value to ApiEventType and
+    # adding a discriminator mapping entry here. CloudEvent is never touched.
 
-  responses:
-    #######################################################
-    #######################################################
-    # ERROR RESPONSE SCHEMA TEMPLATE
-    #   - Objective: Make normative error `status` and `code` values
-    #   - Schema Template rationale:
-    #     - The `allOf` in content.application/json.schema allows a combination of both the generic ErrorInfo schema and the specific schema for this error response,
-    #       which validates that `status` and `code` have only the specified values.
-    #       This `allOf` is used without discriminator because it does not imply any hierarchy between the models, just 2 schemas that must be independently validated.
-    #######################################################
-    #    ErrorResponseSchema:
-    #      ...
-    #      content:
-    #        application/json:
-    #          schema:
-    #            allOf:
-    #              - $ref: '#/components/schemas/ErrorInfo'
-    #              - type: object
-    #                properties:
-    #                  status:
-    #                    enum:
-    #                      - <status>
-    #                  code:
-    #                    enum:
-    #                      - <code1>
-    #                      - <code2>
-    #          examples:
-    #            ExampleKey1:
-    #              value:
-    #                status: <status>
-    #                code: <code1>
-    #                message: <message1>
-    #            ExampleKey2:
-    #              value:
-    #                status: <status>
-    #                code: <code2>
-    #                message: <message2>
-    #######################################################
-    #######################################################
-    Generic400:
-      description: Bad Request
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 400
-                  code:
-                    enum:
-                      - INVALID_ARGUMENT
-                      - OUT_OF_RANGE
-                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
-          examples:
-            GENERIC_400_INVALID_ARGUMENT:
-              description: Invalid Argument. Generic Syntax Exception
-              value:
-                status: 400
-                code: INVALID_ARGUMENT
-                message: Client specified an invalid argument, request body or query param.
-            GENERIC_400_OUT_OF_RANGE:
-              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
-              value:
-                status: 400
-                code: OUT_OF_RANGE
-                message: Client specified an invalid range.
-                # GENERIC_400_{{SPECIFIC_CODE}}:
-                #   description: Specific Syntax Exception regarding a field that is relevant in the context of the API
-                #   value:
-                #     status: 400
-                #     code: "{{SPECIFIC_CODE}}"
-                #     message: Message for specific code
-    Generic401:
-      description: Unauthorized
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 401
-                  code:
-                    enum:
-                      - UNAUTHENTICATED
-          examples:
-            GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated and a new authentication is required
-              value:
-                status: 401
-                code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
-    Generic403:
-      description: Forbidden
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 403
-                  code:
-                    enum:
-                      - PERMISSION_DENIED
-                      - INVALID_TOKEN_CONTEXT
-                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
-          examples:
-            GENERIC_403_PERMISSION_DENIED:
-              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
-              value:
-                status: 403
-                code: PERMISSION_DENIED
-                message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_INVALID_TOKEN_CONTEXT:
-              description: Reflect some inconsistency between information in some field of the API and the related OAuth2 Token
-              value:
-                status: 403
-                code: INVALID_TOKEN_CONTEXT
-                # message: "{{field}} is not consistent with access token."
-                message: "Request body is not consistent with access token."
-                # GENERIC_403_{{SPECIFIC_CODE}}:
-                #   description: Indicate a Business Logic condition that forbids a process not attached to a specific field in the context of the API
-                #   value:
-                #     status: 403
-                #     code: "{{SPECIFIC_CODE}}"
-                #     message: Message for specific code
-    Generic404:
-      description: Not found
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 404
-                  code:
-                    enum:
-                      - NOT_FOUND
-                      - IDENTIFIER_NOT_FOUND
-                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
-          examples:
-            GENERIC_404_NOT_FOUND:
-              description: Resource is not found
-              value:
-                status: 404
-                code: NOT_FOUND
-                message: The specified resource is not found.
-            GENERIC_404_IDENTIFIER_NOT_FOUND:
-              description: Some identifier cannot be matched to a device
-              value:
-                status: 404
-                code: IDENTIFIER_NOT_FOUND
-                message: Device identifier not found.
-                # GENERIC_404_{{SPECIFIC_CODE}}:
-                #   description: Specific situation to highlight the resource/concept not found
-                #   value:
-                #     status: 404
-                #     code: "{{SPECIFIC_CODE}}"
-                #     message: Message for specific code
-    Generic405:
-      description: Method Not Allowed
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 405
-                  code:
-                    enum:
-                      - METHOD_NOT_ALLOWED
-          examples:
-            GENERIC_405_METHOD_NOT_ALLOWED:
-              description: Invalid HTTP verb used with a given endpoint
-              value:
-                status: 405
-                code: METHOD_NOT_ALLOWED
-                message: The requested method is not allowed/supported on the target resource.
-    Generic406:
-      description: Not Acceptable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 406
-                  code:
-                    enum:
-                      - NOT_ACCEPTABLE
-          examples:
-            GENERIC_406_NOT_ACCEPTABLE:
-              description: API Server does not accept the media type (`Accept-*` header) indicated by API client
-              value:
-                status: 406
-                code: NOT_ACCEPTABLE
-                message: The server cannot produce a response matching the content requested by the client through `Accept-*` headers.
-    Generic409:
-      description: Conflict
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 409
-                  code:
-                    enum:
-                      - ABORTED
-                      - ALREADY_EXISTS
-                      - CONFLICT
-                      - INCOMPATIBLE_STATE
-                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
-          examples:
-            GENERIC_409_ABORTED:
-              description: The resource is undergoing modification by another process
-              value:
-                status: 409
-                code: ABORTED
-                message: Resource is being modified by another operation. Please wait, and retry if appropriate.
-            GENERIC_409_ALREADY_EXISTS:
-              description: Trying to create an existing resource
-              value:
-                status: 409
-                code: ALREADY_EXISTS
-                message: The resource that a client tried to create already exists.
-            GENERIC_409_CONFLICT:
-              ###################################
-              # This Error Code is DEPRECATED
-              ###################################
-              description: Duplication of an existing resource
-              value:
-                status: 409
-                code: CONFLICT
-                message: A specified resource duplicate entry found.
-            GENERIC_409_INCOMPATIBLE_STATE:
+    ApiNotificationEvent:
+      description: |
+        API-specific notification event group.
+        Extends the CloudEvent envelope and constrains `type` to the set of
+        event types defined by this API project.
+        Adding a new event type only requires updating ApiEventType and the
+        discriminator mapping below — the CloudEvent base never changes.
+      allOf:
+        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            type:
+              $ref: "#/components/schemas/ApiEventType"
+      discriminator:
+        propertyName: "type"
+        mapping:
+          org.camaraproject.sample-service-subscriptions.v0.event-type1: "#/components/schemas/EventApiSpecific1"
+          org.camaraproject.sample-service-subscriptions.v0.event-type2: "#/components/schemas/EventApiSpecific2"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Callback union (API project-owned)
+    #
+    # oneOf over all valid event groups at the callback endpoint.
+    # Owns no discriminator and applies no constraints of its own.
+    # Its only job is to enumerate which groups are valid for this API.
+    #
+    # To add a new event group: add it to the oneOf list. That is the only
+    # change required at this layer.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    NotificationEvent:
+      description: |
+        Union of all valid notification event groups at the callback endpoint.
+        This schema owns no discriminator — routing within each group is
+        handled by ApiNotificationEvent and SubscriptionLifecycleEvent
+        respectively. Its only responsibility is to enumerate which groups
+        are valid payloads for this API's notification callback.
+      oneOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — API-specific (API project-owned)
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventApiSpecific1:
+      description: event structure for event-type event 1
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
               description: |
-                The status of the referenced resource is not compatible.
-              value:
-                status: 409
-                code: INCOMPATIBLE_STATE
-                message: Resource must be in AVAILABLE state to extend. Current state is UNAVAILABLE.
-                # GENERIC_409_{{SPECIFIC_CODE}}:
-                #   description: Specific conflict situation that is relevant in the context of the API
-                #   value:
-                #     status: 409
-                #     code: "{{SPECIFIC_CODE}}"
-                #     message: Message for specific code
-    Generic410:
-      description: Gone
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 410
-                  code:
-                    enum:
-                      - GONE
-          examples:
-            GENERIC_410_GONE:
-              description: Use in notifications flow to allow API Consumer to indicate that its callback is no longer available
-              value:
-                status: 410
-                code: GONE
-                message: Access to the target resource is no longer available.
-    Generic412:
-      description: Failed precondition
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 412
-                  code:
-                    enum:
-                      - FAILED_PRECONDITION
-          examples:
-            GENERIC_412_FAILED_PRECONDITION:
-              description: Indication by the API Server that the request cannot be processed in current system state
-              value:
-                status: 412
-                code: FAILED_PRECONDITION
-                message: Request cannot be executed in the current system state.
-    Generic415:
-      description: Unsupported Media Type
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 415
-                  code:
-                    enum:
-                      - UNSUPPORTED_MEDIA_TYPE
-          examples:
-            GENERIC_415_UNSUPPORTED_MEDIA_TYPE:
-              description: Payload format of the request is in an unsupported format by the Server. Should not happen
-              value:
-                status: 415
-                code: UNSUPPORTED_MEDIA_TYPE
-                message: The server refuses to accept the request because the payload format is in an unsupported format.
-    Generic422:
-      description: Unprocessable Content
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 422
-                  code:
-                    enum:
-                      - SERVICE_NOT_APPLICABLE
-                      - MISSING_IDENTIFIER
-                      - UNSUPPORTED_IDENTIFIER
-                      - UNNECESSARY_IDENTIFIER
-                      # - "{{SPECIFIC_CODE}}" - API-specific codes added if needed
-          examples:
-            GENERIC_422_SERVICE_NOT_APPLICABLE:
-              description: Service not applicable for the provided identifier
-              value:
-                status: 422
-                code: SERVICE_NOT_APPLICABLE
-                message: The service is not available for the provided identifier.
-            GENERIC_422_MISSING_IDENTIFIER:
-              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
-              value:
-                status: 422
-                code: MISSING_IDENTIFIER
-                message: The device cannot be identified.
-            GENERIC_422_UNSUPPORTED_IDENTIFIER:
-              description: None of the provided identifiers is supported by the implementation
-              value:
-                status: 422
-                code: UNSUPPORTED_IDENTIFIER
-                message: The identifier provided is not supported.
-            GENERIC_422_UNNECESSARY_IDENTIFIER:
-              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
-              value:
-                status: 422
-                code: UNNECESSARY_IDENTIFIER
-                message: The device is already identified by the access token.
-                # GENERIC_422_{{SPECIFIC_CODE}}:
-                #   description: Any semantic condition associated to business logic, specifically related to a field or data structure
-                #   value:
-                #     status: 422
-                #     code: "{{SPECIFIC_CODE}}"
-                #     message: Message for specific code
-    Generic429:
-      description: Too Many Requests
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 429
-                  code:
-                    enum:
-                      - QUOTA_EXCEEDED
-                      - TOO_MANY_REQUESTS
-          examples:
-            GENERIC_429_QUOTA_EXCEEDED:
-              description: Request is rejected due to exceeding a business quota limit
-              value:
-                status: 429
-                code: QUOTA_EXCEEDED
-                message: Out of resource quota.
-            GENERIC_429_TOO_MANY_REQUESTS:
-              description: Access to the API has been temporarily blocked due to rate or spike arrest limits being reached
-              value:
-                status: 429
-                code: TOO_MANY_REQUESTS
-                message: Rate limit reached.
-    Generic500:
-      description: Internal Server Error
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 500
-                  code:
-                    enum:
-                      - INTERNAL
-          examples:
-            GENERIC_500_INTERNAL:
-              description: Problem in Server side. Regular Server Exception
-              value:
-                status: 500
-                code: INTERNAL
-                message: Unknown server error. Typically a server bug.
-    Generic501:
-      description: Not Implemented
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 501
-                  code:
-                    enum:
-                      - NOT_IMPLEMENTED
-          examples:
-            GENERIC_501_NOT_IMPLEMENTED:
-              description: Service not implemented. The use of this code should be avoided as far as possible to get the objective to reach aligned implementations
-              value:
-                status: 501
-                code: NOT_IMPLEMENTED
-                message: This functionality is not implemented yet.
-    Generic502:
-      description: Bad Gateway
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 502
-                  code:
-                    enum:
-                      - BAD_GATEWAY
-          examples:
-            GENERIC_502_BAD_GATEWAY:
-              description: Internal routing problem in the Server side that blocks to manage the service properly
-              value:
-                status: 502
-                code: BAD_GATEWAY
-                message: An upstream internal service cannot be reached.
-    Generic503:
-      description: Service Unavailable
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 503
-                  code:
-                    enum:
-                      - UNAVAILABLE
-          examples:
-            GENERIC_503_UNAVAILABLE:
-              description: Service is not available. Temporary situation usually related to maintenance process in the server side
-              value:
-                status: 503
-                code: UNAVAILABLE
-                message: Service Unavailable.
-    Generic504:
-      description: Gateway Timeout
-      headers:
-        x-correlator:
-          $ref: "#/components/headers/x-correlator"
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/ErrorInfo"
-              - type: object
-                properties:
-                  status:
-                    enum:
-                      - 504
-                  code:
-                    enum:
-                      - TIMEOUT
-          examples:
-            GENERIC_504_TIMEOUT:
-              description: API Server Timeout
-              value:
-                status: 504
-                code: TIMEOUT
-                message: Request timeout exceeded.
+                Event-specific payload for event-type1.
+                Replace with the actual data schema for this event type.
+
+    EventApiSpecific2:
+      description: event structure for event-type event 2
+      allOf:
+        - $ref: "#/components/schemas/ApiNotificationEvent"
+        - type: object
+          properties:
+            data:
+              type: object
+              description: |
+                Event-specific payload for event-type2.
+                Replace with the actual data schema for this event type.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Concrete event schemas — Subscription lifecycle (Commonalities-owned)
+    # Data payloads are referenced from CAMARA_event_common.yaml.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    EventSubscriptionStarted:
+      description: event structure for event subscription started
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionStarted"
+
+    EventSubscriptionUpdated:
+      description: event structure for event subscription updated
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionUpdated"
+
+    EventSubscriptionEnded:
+      description: event structure for event subscription ended
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionLifecycleEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionEnded"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Protocol-specific subscription schemas
+    # Protocol settings are referenced from CAMARA_event_common.yaml.
+    #
+    # Future protocol support (not yet used in CAMARA):
+    # MQTTSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # MQTTSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # AMQPSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # AMQPSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # ApacheKafkaSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # ApacheKafkaSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # NATSSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
+    # NATSSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
+    # ─────────────────────────────────────────────────────────────────────────
+
+    HTTPSubscriptionRequest:
+      description: Subscription request for HTTP-based event delivery.
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionRequest"
+        - type: object
+          properties:
+            protocolSettings:
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
+
+    HTTPSubscriptionResponse:
+      description: Subscription resource returned for HTTP-based event delivery.
+      allOf:
+        - $ref: "#/components/schemas/Subscription"
+        - type: object
+          properties:
+            protocolSettings:
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -370,6 +370,7 @@ components:
       type: object
       required:
         - subscriptions
+        - pagination
       properties:
         subscriptions:
           description: Subscriptions list

--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -330,6 +330,7 @@ components:
       format: int32
       minimum: 1
       maximum: 2147483647
+      default: 1
       description: Current page number (1-indexed).
       example: 1
     PerPage:
@@ -337,6 +338,7 @@ components:
       format: int32
       minimum: 1
       maximum: 100
+      default: 20
       description: Number of items per page.
       example: 20
     TotalCount:

--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -20,11 +20,42 @@ components:
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
       description: OpenID Connect authentication via discovery metadata.
+
   headers:
     x-correlator:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
+
+    x-total-count:
+      description: Total number of items. Mirrors `pagination.totalCount` in the response body.
+      required: false
+      schema:
+        $ref: "#/components/schemas/TotalCount"
+
+    x-total-pages:
+      description: Total number of pages. Mirrors `pagination.totalPages` in the response body.
+      required: false
+      schema:
+        $ref: "#/components/schemas/TotalPages"
+
+    link:
+      description: |
+        Navigation links for paginated results following
+        [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288).
+        Includes only the rels applicable to the current position
+        (`first`, `prev`, `next`, `last`). All original query parameters
+        are preserved in Link URLs.
+        Example:
+          Link: <https://api.example.com/v1/resources?page=1&perPage=20>; rel="first",
+                <https://api.example.com/v1/resources?page=2&perPage=20>; rel="prev",
+                <https://api.example.com/v1/resources?page=4&perPage=20>; rel="next",
+                <https://api.example.com/v1/resources?page=5&perPage=20>; rel="last"
+      required: false
+      schema:
+        type: string
+        maxLength: 8192
+
   parameters:
     x-correlator:
       name: x-correlator
@@ -32,6 +63,27 @@ components:
       description: Correlation id for the different services
       schema:
         $ref: "#/components/schemas/XCorrelator"
+
+    page:
+      name: page
+      in: query
+      description: >
+        Requested page number. Pages are 1-indexed.
+        Values below 1 are rejected with `400 INVALID_ARGUMENT`.
+      required: false
+      schema:
+        $ref: "#/components/schemas/Page"
+
+    perPage:
+      name: perPage
+      in: query
+      description: >
+        Number of subscriptions to return per page.
+        Values outside the allowed range are rejected with `400 INVALID_ARGUMENT`.
+      required: false
+      schema:
+        $ref: "#/components/schemas/PerPage"
+
   schemas:
     XCorrelator:
       type: string
@@ -255,6 +307,53 @@ components:
       format: double
       minimum: -180
       maximum: 180
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Pagination
+    # ─────────────────────────────────────────────────────────────────────────
+
+    Pagination:
+      description: Pagination details helping to navigate through paged results efficiently.
+      type: object
+      properties:
+        page:
+          $ref: "#/components/schemas/Page"
+        perPage:
+          $ref: "#/components/schemas/PerPage"
+        totalCount:
+          $ref: "#/components/schemas/TotalCount"
+        totalPages:
+          $ref: "#/components/schemas/TotalPages"
+
+    Page:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 2147483647
+      description: Current page number (1-indexed).
+      example: 1
+    PerPage:
+      type: integer
+      format: int32
+      minimum: 1
+      maximum: 100
+      description: Number of items per page.
+      example: 20
+    TotalCount:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 2147483647
+      description: Total number of items matching the query, after filters applied. MAY be omitted where a full count query is prohibitively expensive.
+      example: 87
+    TotalPages:
+      type: integer
+      format: int32
+      minimum: 0
+      maximum: 2147483647
+      description: Total number of pages. Equals ceil(totalCount / perPage). MAY be omitted where totalCount is omitted.
+      example: 5
+
 
   responses:
     #######################################################

--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -355,8 +355,6 @@ components:
       maximum: 2147483647
       description: Total number of pages. Equals ceil(totalCount / perPage). MAY be omitted where totalCount is omitted.
       example: 5
-
-
   responses:
     #######################################################
     #######################################################

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -588,13 +588,16 @@ No pagination-specific request headers are required. Pagination is controlled en
 
 #### 4.1.3. Response Body
 
-When paginated response is returned the `pagination` object SHOULD always be present; `totalCount` and `totalPages` MAY be omitted only where a full count query is prohibitively expensive — this MUST be documented per endpoint.
+In paginated response the `pagination` object MUST always be present; `totalCount` and `totalPages` MAY be omitted only where a full count query is prohibitively expensive — this MUST be documented per endpoint.
+
+The example below defines a paginated response schema named `ResourceList`, which includes an `items` array and a required `pagination` object. Note that the names `ResourceList` and `items` are specific to given API.
 
 ```yaml
 ResourceList:
   type: object
   required:
     - items
+    - pagination
   properties:
     items:
       type: array


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Adds pagination support to the `GET /subscriptions` in the sample-service-subscriptions API template, following the Commonalities pagination guidelines. 
- Added `page` and `perPage` query parameters to `GET /subscriptions`, referencing new shared `Page` and `PerPage` parameter components
- Changed the `200` response body from an inline `type: array` to a `SubscriptionList` envelope schema (`items[]` + `pagination` object), consistent with the `ResourceList` pattern
- Added `X-Total-Count`, `X-Total-Pages`, and `Link` (RFC 8288) response headers to the `200` response

Clarification on naming and `pagination` object presence added to Design Guide - based on comments from the review

Adds shared components to CAMARA_common.yaml
  - `components/parameters`: `page`, `perPage`
  - `components/headers`: `x-total-count`, `x-total-pages`, `link`
  - `components/schemas`: `Pagination`, `Page`, `PerPage`, `TotalCount`, `TotalPages`

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #592


#### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

 The `200` response schema changes from a bare array to an object envelope. Clients consuming the raw array will need to update to read `subscriptions[]`

#### Special notes for reviewers:

- `totalCount` and `totalPages` are described as optional in `Pagination` to accommodate endpoints where a full COUNT query is expensive — currently there is no explicit `required:` for  `Page` and `PerPage`.

#### Changelog input

```
Added pagination support to the `GET /subscriptions` in the sample-service-subscriptions API template and shared components to CAMARA_common.yaml.

```

#### Additional documentation 

This section can be blank.



```
docs

```
