### PR TITLE
fix: inline resource-flavoured 400/422 in implicit-subscription template

### DIFF
--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -125,7 +125,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Resource"
         "400":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionBadRequest400"
+          $ref: "#/components/responses/CreateResourceBadRequest400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -133,7 +133,7 @@ paths:
         "409":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic409"
         "422":
-          $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionUnprocessableEntity422"
+          $ref: "#/components/responses/CreateResourceUnprocessableEntity422"
         "429":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
         "500":
@@ -242,6 +242,126 @@ components:
       description: Identifier of the resource to operate on
       schema:
         $ref: "#/components/schemas/ResourceId"
+
+  responses:
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Resource-creation error responses (API-specific)
+    #
+    # API authors: rename to `Create<Resource>BadRequest400` and
+    # `Create<Resource>UnprocessableEntity422` to match the resource being
+    # created, and adjust the `code` enum and `examples` to the codes that
+    # actually apply to the API.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    CreateResourceBadRequest400:
+      description: Problem with the client request
+      headers:
+        x-correlator:
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - INVALID_PROTOCOL
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
+                      - INVALID_SINK
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
+            GENERIC_400_INVALID_PROTOCOL:
+              description: Invalid protocol for event delivery
+              value:
+                status: 400
+                code: INVALID_PROTOCOL
+                message: Only HTTP is supported
+            GENERIC_400_INVALID_CREDENTIAL:
+              description: Invalid sink credential type
+              value:
+                status: 400
+                code: INVALID_CREDENTIAL
+                message: Only Access token or Private key JWT are supported
+            GENERIC_400_INVALID_SINK:
+              description: Invalid sink value
+              value:
+                status: 400
+                code: INVALID_SINK
+                message: sink not valid for the specified protocol
+
+    CreateResourceUnprocessableEntity422:
+      description: Unprocessable Entity
+      headers:
+        x-correlator:
+          $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "../common/CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+                      - PRIVATE_KEY_JWT_NOT_CONFIGURED
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
+            GENERIC_422_PRIVATE_KEY_JWT_NOT_CONFIGURED:
+              description: Private key JWT sink credential type is used but no configuration was pre-shared
+              value:
+                status: 422
+                code: PRIVATE_KEY_JWT_NOT_CONFIGURED
+                message: Private key JWT credential type cannot be used because no configuration was pre-shared.
 
   schemas:
 


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

The implicit-subscription API template `artifacts/api-templates/sample-implicit-events.yaml` referenced explicit-subscription-named error responses on its `createResource` operation:

- `"400": $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionBadRequest400"`
- `"422": $ref: "../common/CAMARA_event_common.yaml#/components/responses/CreateSubscriptionUnprocessableEntity422"`

`createResource` is a resource-CRUD operation, so the `CreateSubscription*` naming carries explicit-subscription vocabulary into a resource-creation operation, and the contained codes mix sink/event-delivery codes with explicit-subscription-only ones (`MULTIEVENT_*`). The two CAMARA APIs using the implicit-subscription pattern today (QualityOnDemand, CarrierBillingCheckOut) both define their 400/422 responses inline with resource-flavoured names rather than referencing the Commonalities `CreateSubscription*` schemas.

This PR aligns the template with that in-the-wild convention:

- Adds two inline response definitions in `components.responses`: 
  - `CreateResourceBadRequest400` (codes `INVALID_ARGUMENT`, `OUT_OF_RANGE`, `INVALID_PROTOCOL`, `INVALID_CREDENTIAL`, `INVALID_TOKEN`, `INVALID_SINK`)
  - `CreateResourceUnprocessableEntity422` (codes `SERVICE_NOT_APPLICABLE`, `MISSING_IDENTIFIER`, `UNSUPPORTED_IDENTIFIER`, `UNNECESSARY_IDENTIFIER`, `PRIVATE_KEY_JWT_NOT_CONFIGURED`). Drops the `MULTIEVENT_*` codes since those describe explicit-subscription concepts.
- Updates the `createResource` `400` and `422` responses to reference these local definitions.
- Adds a comment instructing API authors to rename to `Create<Resource>BadRequest400` / `Create<Resource>UnprocessableEntity422` and adjust the code list to the resource being created.

`artifacts/common/CAMARA_event_common.yaml` is not modified — the existing `CreateSubscription*` responses remain correct for explicit-subscription consumers.

#### Which issue(s) this PR fixes:

Fixes #627

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

- The diff is a single file: `artifacts/api-templates/sample-implicit-events.yaml`, +122/-2.
- Local Spectral run (with `hdamker/tooling/linting/config/.spectral.yaml`) on the modified file produces 2 warnings — both `oas3-unused-component` on `EventApiSpecific1` / `EventApiSpecific2`. Verified pre-existing on `main` (Spectral can't follow `discriminator.mapping` string references). Not introduced by this PR.
- Local Redocly bundle smoke test succeeds.

#### Changelog input

```
 release-note
Implicit-subscription template: inline resource-flavoured 400/422 responses.
```

#### Additional documentation 

This section can be blank.



```
docs

```
