### PR TITLE
Fix issue #619 - Simplify usage of PrivateKeyJwtCredentials for event notification

### DIFF
--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -311,7 +311,7 @@ components:
             The sink URL registered for notifications on this resource, if any.
             `sinkCredential` is deliberately not echoed in responses.
         sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential"
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 
     # ─────────────────────────────────────────────────────────────────────────
     # API-specific event type enum (contains sample-implicit-events placeholders)

--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -310,6 +310,8 @@ components:
           description: |
             The sink URL registered for notifications on this resource, if any.
             `sinkCredential` is deliberately not echoed in responses.
+        sinkCredential:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential"
 
     # ─────────────────────────────────────────────────────────────────────────
     # API-specific event type enum (contains sample-implicit-events placeholders)

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -314,7 +314,7 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential"
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -313,6 +313,8 @@ components:
           pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
+        sinkCredential:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/PrivateKeyJWTCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.

--- a/artifacts/common/CAMARA_event_common.yaml
+++ b/artifacts/common/CAMARA_event_common.yaml
@@ -344,21 +344,24 @@ components:
         - type: object
           properties:
             clientId:
-              description: The client ID used to authenticate when requesting an access token using PRIVATE_KEY_JWT. This information should only be included in the request.
+              description: The client ID used to authenticate when requesting an access token using PRIVATE_KEY_JWT.
               type: string
               maxLength: 128
+              writeOnly: true
             tokenUri:
-              description: The URI where to request an access token using PRIVATE_KEY_JWT. This information should only be included in the request.
+              description: The URI where to request an access token using PRIVATE_KEY_JWT.
               type: string
               format: uri
               maxLength: 2048
               pattern: ^https:\/\/.+$
+              writeOnly: true
             jwksUri:
-              description: The URI used to request the public key to verify that the JWT assertion was signed by PRIVATE_KEY_JWT. This information should only be included in the response.
+              description: The URI used to request the public key to verify that the JWT assertion was signed by PRIVATE_KEY_JWT.
               type: string
               format: uri
               maxLength: 2048
               pattern: ^https:\/\/.+$
+              readOnly: true
 
     # ─────────────────────────────────────────────────────────────────────────
     # Section 5: Subscription lifecycle data

--- a/artifacts/common/CAMARA_event_common.yaml
+++ b/artifacts/common/CAMARA_event_common.yaml
@@ -316,6 +316,7 @@ components:
               description: REQUIRED. An access token is a token granting access to the target resource.
               type: string
               maxLength: 4096
+              writeOnly: true
             accessTokenExpiresUtc:
               type: string
               format: date-time
@@ -329,6 +330,7 @@ components:
             accessTokenType:
               description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
               type: string
+              writeOnly: true
               enum:
                 - bearer
           required:

--- a/artifacts/common/CAMARA_event_common.yaml
+++ b/artifacts/common/CAMARA_event_common.yaml
@@ -338,9 +338,27 @@ components:
 
     PrivateKeyJWTCredential:
       type: object
-      description: Use PRIVATE_KEY_JWT to get an access token. The authorization server information needed for this type of sink credential (token endpoint, client ID, JWKS URL) is shared upfront between the client and the CAMARA entity. This type of credential is to be used by clients that have an authorization server.
+      description: Use PRIVATE_KEY_JWT to get an access token. This type of credential is to be used by clients that have an authorization server.
       allOf:
         - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          properties:
+            clientId:
+              description: The client ID used to authenticate when requesting an access token using PRIVATE_KEY_JWT. This information should only be included in the request.
+              type: string
+              maxLength: 128
+            tokenUri:
+              description: The URI where to request an access token using PRIVATE_KEY_JWT. This information should only be included in the request.
+              type: string
+              format: uri
+              maxLength: 2048
+              pattern: ^https:\/\/.+$
+            jwksUri:
+              description: The URI used to request the public key to verify that the JWT assertion was signed by PRIVATE_KEY_JWT. This information should only be included in the response.
+              type: string
+              format: uri
+              maxLength: 2048
+              pattern: ^https:\/\/.+$
 
     # ─────────────────────────────────────────────────────────────────────────
     # Section 5: Subscription lifecycle data

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -636,7 +636,7 @@ The client ID uniquely identifies the application ([RFC 6749, Section 2.2](https
 
 The JWK Set ((JSON Web Key Set)) contains the cryptographic keys used for authentication ([RFC 7517](https://www.rfc-editor.org/rfc/rfc7517.html)) 
 
-This information could be shared out of band (manual exchange, contract data, via the Operate API, etc.) or as input using PrivateKeyJWTCredential credentials.
+This information could be shared out of band (manual exchange, contract data, via the Operate API, etc.) or as properties of `sinkCredential` object in subscription request/response.
 
 ## Appendix A: Notification authentication flows
 

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -684,7 +684,7 @@ sequenceDiagram
   opt Using PRIVATE_KEY_JWT sink credential attributes (credentials exchanged in band)
     note over appclient,cspclient: Onboarding: <br> API Consumer shares nothing
     opt Subscription
-    appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> tokenUri:<API Consumer 2>/tokenUri,,<br> clientId:<API Provider clientId> },<br>...}
+    appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> tokenUri:<API Consumer 2>/tokenUri,<br> clientId:<API Provider clientId> },<br>...}
     cspres -->> appclient: 201 Created<br>Body {<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> jwksUri:<API Provider>/jwksUri}
   end
     opt Authentication

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -681,7 +681,7 @@ sequenceDiagram
       end
     end
   end
-  opt Using PRIVATE_KEY_JWT sink credential type (credentials exchanged in bound)
+  opt Using PRIVATE_KEY_JWT sink credential attributes (credentials exchanged in band)
     note over appclient,cspclient: Onboarding: <br> API Consumer shares nothing
     opt Subscription
     appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> tokenUri:<API Consumer 2>/tokenUri,,<br> clientId:<API Provider clientId> },<br>...}

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -671,7 +671,7 @@ sequenceDiagram
     end
   end
 
-  opt Using PRIVATE_KEY_JWT sink credential type (credentials exchanged out of bound)
+  opt Using PRIVATE_KEY_JWT sink credential type (credentials exchanged out of band)
     note over appclient,cspclient: Onboarding: <br> API Consumer shares <Token Endpoint> and <Client ID><br>API Provider shares <JWKS URI>
     opt Subscription
       appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT },<br>...}

--- a/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
+++ b/documentation/CAMARA-API-Event-Subscription-and-Notification-Guide.md
@@ -636,6 +636,8 @@ The client ID uniquely identifies the application ([RFC 6749, Section 2.2](https
 
 The JWK Set ((JSON Web Key Set)) contains the cryptographic keys used for authentication ([RFC 7517](https://www.rfc-editor.org/rfc/rfc7517.html)) 
 
+This information could be shared out of band (manual exchange, contract data, via the Operate API, etc.) or as input using PrivateKeyJWTCredential credentials.
+
 ## Appendix A: Notification authentication flows
 
 The following diagram describes the authentication flows for API Consumers with different authentication capabilities. Depending on those capabilities the sink credential type used will be `ACCESSTOKEN` or `PRIVATE_KEY_JWT`
@@ -669,7 +671,7 @@ sequenceDiagram
     end
   end
 
-  opt Using PRIVATE_KEY_JWT sink credential type
+  opt Using PRIVATE_KEY_JWT sink credential type (credentials exchanged out of bound)
     note over appclient,cspclient: Onboarding: <br> API Consumer shares <Token Endpoint> and <Client ID><br>API Provider shares <JWKS URI>
     opt Subscription
       appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT },<br>...}
@@ -678,6 +680,13 @@ sequenceDiagram
       cspres -->> appclient: Invalid sink credential type or missing pre-shared information 
       end
     end
+  end
+  opt Using PRIVATE_KEY_JWT sink credential type (credentials exchanged in bound)
+    note over appclient,cspclient: Onboarding: <br> API Consumer shares nothing
+    opt Subscription
+    appclient ->> cspres: POST /subscriptions<br>Body: {<br>sink: <API Consumer 2>/sink,<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> tokenUri:<API Consumer 2>/tokenUri,,<br> clientId:<API Provider clientId> },<br>...}
+    cspres -->> appclient: 201 Created<br>Body {<br>sinkCredential:{ credentialType: PRIVATE_KEY_JWT,<br> jwksUri:<API Provider>/jwksUri}
+  end
     opt Authentication
       cspclient->>appauth: Get Access Token<br>from API Consumer <Token Endpoint><br>with <signed JWT credentials>
       appauth->>cspauth: Fetch <Public Key Set> from <JWKS URI>


### PR DESCRIPTION
Simplify usage of PrivateKeyJwtCredentials for event notification by adding clientId, tokenUri and jwksUri to PrivateKeyJwtCredentials

#### What type of PR is this?

<!-- Add one of the following kinds: -->
* enhancement/feature

#### What this PR does / why we need it:
By integrating all the necessary information into PrivateKeyJwtCredentials, it is no longer necessary to specify it via the Operate API. Parameter changes do not require any modification of the contractual data.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes [#619 ](https://github.com/camaraproject/Commonalities/issues/619)


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:



#### Changelog input

```
 Add clientId, tokenUri and jwksUri to PrivateKeyJwtCredentials into CAMARA_event_common.yaml (request part)
 Add also sinkCredential of type PrivateKeyJwtCredentials into sample-service-subscriptions.yaml (response part)

```

#### Additional documentation 

```
```
