### PR TITLE
Reset version to wip

### DIFF
--- a/VERSION.yaml
+++ b/VERSION.yaml
@@ -1,1 +1,1 @@
-version: 0.8.0
+version: wip

--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -78,7 +78,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -45,7 +45,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/artifacts/api-templates/sample-service.yaml
+++ b/artifacts/api-templates/sample-service.yaml
@@ -63,7 +63,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/{apiRepository}

--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -12,7 +12,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 components:
   securitySchemes:

--- a/artifacts/common/CAMARA_event_common.yaml
+++ b/artifacts/common/CAMARA_event_common.yaml
@@ -11,7 +11,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 components:
   securitySchemes:

--- a/artifacts/common/info-description-templates.yaml
+++ b/artifacts/common/info-description-templates.yaml
@@ -25,7 +25,7 @@
 #   section "Mandatory template for `info.description` in CAMARA API specs"
 
 info:
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 authorization-and-authentication:
   content: |

--- a/artifacts/notification-templates/sample-notification.yaml
+++ b/artifacts/notification-templates/sample-notification.yaml
@@ -11,7 +11,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: wip
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -1,6 +1,6 @@
 Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
-    CAMARA Commonalities: 0.8.0
+    CAMARA Commonalities: wip
     
     Common error scenarios for operations with device as input either in the request
     body or implied from the access.

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -1,6 +1,6 @@
 Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
 
-    CAMARA Commonalities: 0.8.0
+    CAMARA Commonalities: wip
 
     Common error scenarios for operations with phoneNumber as input either in the request
     body or implied from the access

--- a/artifacts/testing/event-subscription-template.feature
+++ b/artifacts/testing/event-subscription-template.feature
@@ -1,7 +1,7 @@
 @<xxx>
 Feature: Camara Template Subscriptions API - Operations on subscriptions
 
-    CAMARA Commonalities: 0.8.0
+    CAMARA Commonalities: wip
 
   # This feature file is to be used by CAMARA subproject when an event subscription resource is provided.
   # We use <xxx> as the subscription resource prefix.

--- a/artifacts/testing/sample-implicit-events-template.feature
+++ b/artifacts/testing/sample-implicit-events-template.feature
@@ -1,6 +1,6 @@
 Feature: CAMARA Template Artifact - Test scenarios for sample-implicit-events.yaml
 
-    CAMARA Commonalities: 0.8.0
+    CAMARA Commonalities: wip
     Additional Common test scenarios for operations defined in sample-implicit-events.yaml.
     
     Common test scenarios for operations defined in sample-implicit-events.yaml are already defined in sample-service-template.feature. 

--- a/artifacts/testing/sample-service-template.feature
+++ b/artifacts/testing/sample-service-template.feature
@@ -1,6 +1,6 @@
 Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
 
-    CAMARA Commonalities: 0.8.0
+    CAMARA Commonalities: wip
     Common test scenarios for operations defined in sample-service.yaml.
 
     NOTES:


### PR DESCRIPTION
#### What type of PR is this?

* cleanup

#### What this PR does / why we need it:

Reset version to `wip` after the r4.3 release by replacing all occurrences of `0.8.0` with `wip` in:
- `VERSION.yaml`
- artifact YAML files (`x-camara-commonalities` field)
- testing `.feature` files (`CAMARA Commonalities` field)

Historical references in `README.md` and `CHANGELOG.md` are left unchanged.

#### Which issue(s) this PR fixes:

Fixes #


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.

```
docs

```