### PR TITLE
Define common Sink schema to be used by API templates

### DIFF
--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -442,7 +442,12 @@ components:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
         sink:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
+          description: |
+            The HTTPS URL where event notifications for this resource will be
+            delivered. Omit this field (and `sinkCredential`) to create the
+            resource without event notifications.
+          allOf:
+            - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 
@@ -462,7 +467,11 @@ components:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
         sink:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
+          description: |
+            The sink URL registered for notifications on this resource, if any.
+            `sinkCredential` is deliberately not echoed in responses.
+          allOf:
+            - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 

--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -442,15 +442,7 @@ components:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
         sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: |
-            The HTTPS URL where event notifications for this resource will be
-            delivered. Omit this field (and `sinkCredential`) to create the
-            resource without event notifications.
-          example: "https://endpoint.example.com/sink"
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 

--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -462,12 +462,7 @@ components:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
         sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          description: |
-            The sink URL registered for notifications on this resource, if any.
-            `sinkCredential` is deliberately not echoed in responses.
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -291,7 +291,9 @@ components:
         protocol:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
         sink:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
+          description: The address to which events shall be delivered using the selected protocol.
+          allOf:
+            - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
@@ -332,7 +334,9 @@ components:
         protocol:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
         sink:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
+          description: The address to which events shall be delivered using the selected protocol.
+          allOf:
+            - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -291,12 +291,7 @@ components:
         protocol:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
         sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
@@ -337,12 +332,7 @@ components:
         protocol:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
         sink:
-          type: string
-          format: uri
-          maxLength: 2048
-          pattern: ^https:\/\/.+$
-          description: The address to which events shall be delivered using the selected protocol.
-          example: "https://endpoint.example.com/sink"
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Sink"
         sinkCredential:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:

--- a/artifacts/common/CAMARA_event_common.yaml
+++ b/artifacts/common/CAMARA_event_common.yaml
@@ -259,11 +259,19 @@ components:
     #     - subject
 
     # ─────────────────────────────────────────────────────────────────────────
-    # Section 4: Sink credentials
+    # Section 4: Sink and sink credentials
     #
     # Authentication and authorization information for event delivery.
     # These are Commonalities-owned and identical across all CAMARA APIs.
     # ─────────────────────────────────────────────────────────────────────────
+
+    Sink:
+      description: The address to which events shall be delivered using the selected protocol.
+      type: string
+      format: uri
+      maxLength: 2048
+      pattern: ^https:\/\/.+$
+      example: "https://endpoint.example.com/sink"
 
     SinkCredential:
       description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
The API templates repeat the definition of the `sink` property. By defining a common schema, this duplication can be avoided.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #647 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Define common Sink schema to be used by API templates
```

#### Additional documentation 
None