### PR TITLE
Remove syncCredentials property from response body schema of API templates

### DIFF
--- a/artifacts/api-templates/sample-implicit-events.yaml
+++ b/artifacts/api-templates/sample-implicit-events.yaml
@@ -476,8 +476,6 @@ components:
           description: |
             The sink URL registered for notifications on this resource, if any.
             `sinkCredential` is deliberately not echoed in responses.
-        sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
 
     # ─────────────────────────────────────────────────────────────────────────
     # API-specific event type enum (contains sample-implicit-events placeholders)

--- a/artifacts/api-templates/sample-service-subscriptions.yaml
+++ b/artifacts/api-templates/sample-service-subscriptions.yaml
@@ -343,8 +343,6 @@ components:
           pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
This PR removes the `sinkCredentials` property from the response body schema of the sample-implicit-events.yaml and sample-service-subscriptions.yaml API templates.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #649

#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
The templates are just guidance to API designers, so hopefully they were removing this property anyway.

#### Changelog input

```
 release-note
 - Remove syncCredentials property from response body schema of API templates
```

#### Additional documentation 