### PR TITLE
Add additional newline after SGML comments so that Swagger editor displays markdown header properly

### DIFF
--- a/artifacts/common/info-description-templates.yaml
+++ b/artifacts/common/info-description-templates.yaml
@@ -30,6 +30,7 @@ info:
 authorization-and-authentication:
   content: |
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
@@ -46,6 +47,7 @@ authorization-and-authentication:
 additional-error-responses:
   content: |
     <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
+
     # Additional CAMARA error responses
 
     The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
@@ -62,6 +64,7 @@ additional-error-responses:
 request-body-strictness:
   content: |
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
+
     # Request body strictness
 
     This API rejects requests with JSON request bodies that contain properties not declared in this specification, at any nesting level. Unknown properties result in a `400 INVALID_ARGUMENT` response.
@@ -76,6 +79,7 @@ request-body-strictness:
 identifying-device-from-access-token:
   content: |
     <!-- CAMARA:MANDATORY:identifying-device-from-access-token:BEGIN -->
+
     # Identifying the device from the access token
 
     This API requires the API consumer to identify a device as the subject of the API as follows:
@@ -100,6 +104,7 @@ identifying-device-from-access-token:
 identifying-phone-number-from-access-token:
   content: |
     <!-- CAMARA:MANDATORY:identifying-phone-number-from-access-token:BEGIN -->
+
     # Identifying the phone number from the access token
 
     This API requires the API consumer to identify a phone number as the subject of the API as follows:


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
The swagger editor is ignoring the markdown header directive that immediately follows SGML comments: e.g.
```
<!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
# Authorization and authentication
```
The solution is to add an additional newline following the comment. e.g.:
```
<!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->

# Authorization and authentication
```

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #651 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
Redoc viewer is unaffected by this


#### Changelog input

```
 release-note
 - Add additional newline after SGML comments so that Swagger editor displays markdown header properly
```

#### Additional documentation 
None