### PR TITLE
Define SingleIpv6Address schema for general use

### DIFF
--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -205,6 +205,13 @@ components:
       maxLength: 15
       example: "84.125.93.10"
 
+    SingleIpv6Address:
+      description: A single IPv6 address with no subnet mask
+      type: string
+      format: ipv6
+      maxLength: 45
+      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+
     Port:
       description: TCP or UDP port number
       type: integer
@@ -215,10 +222,8 @@ components:
     DeviceIpv6Address:
       description: |
         The device should be identified by the observed IPv6 address, or by any single IPv6 address from within the subnet allocated to the device (e.g. adding ::0 to the /64 prefix).
-      type: string
-      format: ipv6
-      maxLength: 45
-      example: 2001:db8:85a3:8d3:1319:8a2e:370:7344
+      allOf:
+        - $ref: "#/components/schemas/SingleIpv6Address"
 
     Area:
       description: Base schema for all areas


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
Defines a common SingleIpv6Address schema with generic description that can be used for all IPv6 contexts, and not just for devices.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #653 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If indicated yes above, please describe the breaking change(s). -->

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Define SingleIpv6Address schema for general use
```

#### Additional documentation 
None