### PR TITLE
Bound integer schema values to the 53-bit integer range

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -105,7 +105,8 @@ This part captures a detailed description of all the data structures used in the
 
 - If the data type is object, list of required properties.
 - If the data type is array, `maxItems` property MUST be specified.
-- If the data type is integer, format (`int32` or `int64`) and range (`minimum` and `maximum`properties) MUST be specified.
+- If the data type is integer, format (`int32` or `int64`) and range (`minimum` and `maximum` properties) MUST be specified.
+  - Numeric schema values (e.g. `minimum`, `maximum`, `default`, `enum` values, examples) MUST be within the 53-bit integer range (-9007199254740991 through 9007199254740991). As noted in the [OpenAPI Format Registry](https://spec.openapis.org/registry/format/int64), values outside this range cause interoperability problems with recipients that parse JSON numbers into double-precision (binary64) representation and may be silently altered. A property whose domain requires larger values MUST instead be modeled as a `string` with an appropriate `pattern`, as recommended by the registry.
 - List of properties within the object data, including:
    - Property name
    - Property description

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -106,7 +106,7 @@ This part captures a detailed description of all the data structures used in the
 - If the data type is object, list of required properties.
 - If the data type is array, `maxItems` property MUST be specified.
 - If the data type is integer, format (`int32` or `int64`) and range (`minimum` and `maximum` properties) MUST be specified.
-  - Numeric schema values (e.g. `minimum`, `maximum`, `default`, `enum` values, examples) MUST be within the 53-bit integer range (-9007199254740991 through 9007199254740991). As noted in the [OpenAPI Format Registry](https://spec.openapis.org/registry/format/int64), values outside this range cause interoperability problems with recipients that parse JSON numbers into double-precision (binary64) representation and may be silently altered. A property whose domain requires larger values MUST instead be modeled as a `string` with an appropriate `pattern`, as recommended by the registry.
+  - Numeric schema values (e.g. `minimum`, `maximum`, `default`, `enum` values, examples) MUST be within the 53-bit integer range (-9007199254740991 through 9007199254740991). As noted in the [OpenAPI Format Registry](https://spec.openapis.org/registry/format/int64), values outside this range cause interoperability problems with recipients that parse JSON numbers into double-precision (binary64) representation and may be silently altered. A property whose domain requires values outside the 53-bit range MUST instead be modeled as a `string` with an appropriate `pattern`, as recommended by the registry.
 - List of properties within the object data, including:
    - Property name
    - Property description


### PR DESCRIPTION
#### What type of PR is this?

* documentation

#### What this PR does / why we need it:

Adds a normative constraint to §2.2 Data Definitions: numeric schema values of integer properties MUST be within the 53-bit integer range (-9007199254740991 through 9007199254740991), following the recommendation of the [OpenAPI Format Registry](https://spec.openapis.org/registry/format/int64). Values outside this range cause interoperability problems with recipients that parse JSON numbers into double-precision (binary64) representation and may be silently altered — observed in a real release artifact (see linked issue). A property whose domain requires larger values is modeled as a `string` instead, as the registry recommends.

Also fixes a missing space in the existing integer bullet.

#### Which issue(s) this PR fixes:

Fixes #648

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Per the issue discussion, the rationale references the OpenAPI Format Registry recommendation rather than language-specific limits. The constraint is already enforced by CAMARA validation tooling (rule S-038, `camara-integer-safe-range`); this PR adds the corresponding Design Guide text.

#### Changelog input

```
 release-note
Integer schema values must be within the 53-bit integer range (-9007199254740991 through 9007199254740991); properties with genuinely larger domains are modeled as strings, per the OpenAPI Format Registry recommendation.
```

#### Additional documentation 

This section can be blank.

```
docs
```
