### PR TITLE
fix: correct Date schema indentation in CAMARA_common.yaml

### DIFF
--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -92,13 +92,13 @@ components:
       maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
 
-     Date:
-        type: string
-        description: The date, using [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) full-date format "YYYY-MM-DD"
-        format: date
-        minLength: 10
-        maxLength: 10
-        example: "2023-07-03"
+    Date:
+      type: string
+      description: The date, using [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) full-date format "YYYY-MM-DD"
+      format: date
+      minLength: 10
+      maxLength: 10
+      example: "2023-07-03"
 
     DateTime:
       type: string


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

The `Date` schema in `artifacts/common/CAMARA_common.yaml` was added at 5-space / 8-space indentation instead of the 4-space / 6-space used by every sibling schema under `components/schemas`. As a result the whole file fails to parse as YAML, so any tooling or API repository that loads `CAMARA_common.yaml` cannot read it.

This PR re-indents the `Date` schema to 4/6 spaces. It is a whitespace-only change with no effect on the schema content.

#### Which issue(s) this PR fixes:

<!-- No dedicated issue; this is the acute breakage that motivated #668. -->
Related to #668

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Whitespace-only change. Before the fix, `yamllint` reports `syntax error: expected <block end>, but found '<block mapping start>'` at the `Date:` line and `wrong indentation: expected 7 but found 8`; after the fix the file parses and yamllint is clean.

#### Changelog input

```
 release-note
Fixed the indentation of the Date schema in CAMARA_common.yaml so the file parses as valid YAML again.
```

#### Additional documentation

This section can be blank.
