### PR TITLE
Normalize artifact line endings and Gherkin formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Normalize all text files to LF line endings on commit.
+# Contributors on Windows will still see CRLF in their working tree
+# (if core.autocrlf is set), but the repository always stores LF.
+* text=auto eol=lf
+
+# Explicitly mark binary formats so Git never attempts EOL conversion.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar.gz binary
+*.pptx binary
+*.docx binary
+*.xlsx binary
+
+# Slim down release artifacts by excluding meeting minutes.
+/documentation/MeetingMinutes export-ignore

--- a/artifacts/testing/C01-device-errors.feature
+++ b/artifacts/testing/C01-device-errors.feature
@@ -1,7 +1,7 @@
 Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
     CAMARA Commonalities: wip
-    
+
     Common error scenarios for operations with device as input either in the request
     body or implied from the access.
 
@@ -18,7 +18,7 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
     * {operationId} has to be substituted to the value of operationId for the tested operation
 
-    * {path_to_device} has to be substituted to the JSON path of the device property in the body request, typically 
+    * {path_to_device} has to be substituted to the JSON path of the device property in the body request, typically
     "$.device" or "$.config.subscriptionDetail.device" for Subscription APIs
 
   # This feature file is to be used by CAMARA subproject when Common error scenarios for operations with device as input either in the request body or implied from the access.
@@ -27,82 +27,82 @@ Feature: CAMARA Common Artifact C01 - Test scenarios for device errors
 
     # Error scenarios for management of input parameter device
 
-    @{feature_identifier}_C01.01_device_empty
-    Scenario: The device value is an empty object
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "{path_to_device}" is set to: {}
-        When the request "{operationId}" is sent
-        Then the response status code is 400
-        And the response property "$.status" is 400
-        And the response property "$.code" is "INVALID_ARGUMENT"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C01.01_device_empty
+  Scenario: The device value is an empty object
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "{path_to_device}" is set to: {}
+    When the request "{operationId}" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
 
-    @{feature_identifier}_C01.02_device_identifiers_not_schema_compliant
-    Scenario Outline: Some device identifier value does not comply with the schema
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
-        When the request "{operationId}" is sent
-        Then the response status code is 400
-        And the response property "$.status" is 400
-        And the response property "$.code" is "INVALID_ARGUMENT"
-        And the response property "$.message" contains a user friendly text
-        
-        Examples:
-            | device_identifier                        | oas_spec_schema                             |
-            | {path_to_device}.phoneNumber             | #/components/schemas/PhoneNumber             |
-            | {path_to_device}.ipv4Address             | #/components/schemas/DeviceIpv4Addr          |
-            | {path_to_device}.ipv6Address             | #/components/schemas/DeviceIpv6Address       |
-            | {path_to_device}.networkAccessIdentifier | #/components/schemas/NetworkAccessIdentifier |
+  @{feature_identifier}_C01.02_device_identifiers_not_schema_compliant
+  Scenario Outline: Some device identifier value does not comply with the schema
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "<device_identifier>" does not comply with the OAS schema at "<oas_spec_schema>"
+    When the request "{operationId}" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+    Examples:
+      | device_identifier                        | oas_spec_schema                             |
+      | {path_to_device}.phoneNumber             | #/components/schemas/PhoneNumber             |
+      | {path_to_device}.ipv4Address             | #/components/schemas/DeviceIpv4Addr          |
+      | {path_to_device}.ipv6Address             | #/components/schemas/DeviceIpv6Address       |
+      | {path_to_device}.networkAccessIdentifier | #/components/schemas/NetworkAccessIdentifier |
 
     # This scenario may happen e.g. with 2-legged access tokens, which do not identify a single device.
-    @{feature_identifier}_C01.03_device_not_found
-    Scenario: Some identifier cannot be matched to a device
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "{path_to_device}" is compliant with the schema but does not identify a valid device
-        When the request "{operationId}" is sent
-        Then the response status code is 404
-        And the response property "$.status" is 404
-        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C01.03_device_not_found
+  Scenario: Some identifier cannot be matched to a device
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "{path_to_device}" is compliant with the schema but does not identify a valid device
+    When the request "{operationId}" is sent
+    Then the response status code is 404
+    And the response property "$.status" is 404
+    And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
 
-    @{feature_identifier}_C01.04_unnecessary_device
-    Scenario: Device not to be included when it can be deduced from the access token
-        Given the header "Authorization" is set to a valid access token identifying a device
-        And the request body property "{path_to_device}" is set to a valid device
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
-        And the response property "$.message" contains a user-friendly text
+  @{feature_identifier}_C01.04_unnecessary_device
+  Scenario: Device not to be included when it can be deduced from the access token
+    Given the header "Authorization" is set to a valid access token identifying a device
+    And the request body property "{path_to_device}" is set to a valid device
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
 
-    @{feature_identifier}_C01.05_missing_device
-    Scenario: Device not included and cannot be deduced from the access token
-        Given the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "{path_to_device}" is not included
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "MISSING_IDENTIFIER"
-        And the response property "$.message" contains a user-friendly text
+  @{feature_identifier}_C01.05_missing_device
+  Scenario: Device not included and cannot be deduced from the access token
+    Given the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "{path_to_device}" is not included
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MISSING_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
 
-    @{feature_identifier}_C01.06_unsupported_device
-    Scenario: None of the provided device identifiers is supported by the implementation
-        Given that some types of device identifiers are not supported by the implementation
-        And the header "Authorization" is set to a valid access token which does not identify a single device
-        And the request body property "{path_to_device}" only includes device identifiers not supported by the implementation
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
-        And the response property "$.message" contains a user-friendly text
+  @{feature_identifier}_C01.06_unsupported_device
+  Scenario: None of the provided device identifiers is supported by the implementation
+    Given that some types of device identifiers are not supported by the implementation
+    And the header "Authorization" is set to a valid access token which does not identify a single device
+    And the request body property "{path_to_device}" only includes device identifiers not supported by the implementation
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNSUPPORTED_IDENTIFIER"
+    And the response property "$.message" contains a user-friendly text
 
     # When the service is only offered to certain types of devices or subscriptions, e.g. IoT, B2C, etc.
-    @{feature_identifier}_C01.07_device_not_supported
-    Scenario: Service not available for the device
-        Given that the service is not available for all devices commercialized by the operator
-        And a valid device, identified by the token or provided in the request body, for which the service is not applicable
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
-        And the response property "$.message" contains a user-friendly text
+  @{feature_identifier}_C01.07_device_not_supported
+  Scenario: Service not available for the device
+    Given that the service is not available for all devices commercialized by the operator
+    And a valid device, identified by the token or provided in the request body, for which the service is not applicable
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user-friendly text

--- a/artifacts/testing/C02-phoneNumber-errors.feature
+++ b/artifacts/testing/C02-phoneNumber-errors.feature
@@ -18,7 +18,7 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
 
     * {operationId} has to be substituted to the value of operationId for the tested operation
 
-    * {path_to_phoneNumber} has to be substituted to the JSON path of the phoneNumber property in the body request, typically 
+    * {path_to_phoneNumber} has to be substituted to the JSON path of the phoneNumber property in the body request, typically
     "$.phoneNumber" or "$.config.subscriptionDetail.phoneNumber" for Subscription APIs
 
   # This feature file is to be used by CAMARA subproject when Common error scenarios for operations with phoneNumber as input either in the request body or implied from the access
@@ -27,53 +27,53 @@ Feature: CAMARA Common Artifact C02 - Test scenarios for phoneNumber errors
 
     # Error scenarios for management of input parameter phoneNumber
 
-    @{feature_identifier}_C02.01_phone_number_not_schema_compliant
-    Scenario: Phone number value does not comply with the schema
-        Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "{path_to_phoneNumber}" does not comply with the OAS schema at "#/components/schemas/PhoneNumber"
-        When the request "{operationId}" is sent
-        Then the response status code is 400
-        And the response property "$.status" is 400
-        And the response property "$.code" is "INVALID_ARGUMENT"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C02.01_phone_number_not_schema_compliant
+  Scenario: Phone number value does not comply with the schema
+    Given the header "Authorization" is set to a valid access token which does not identify a single phone number
+    And the request body property "{path_to_phoneNumber}" does not comply with the OAS schema at "#/components/schemas/PhoneNumber"
+    When the request "{operationId}" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
 
-    @{feature_identifier}_C02.02_phone_number_not_found
-    Scenario: Phone number not found
-        Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "{path_to_phoneNumber}" is compliant with the schema but does not identify a valid phone number
-        When the request "{operationId}" is sent
-        Then the response status code is 404
-        And the response property "$.status" is 404
-        And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C02.02_phone_number_not_found
+  Scenario: Phone number not found
+    Given the header "Authorization" is set to a valid access token which does not identify a single phone number
+    And the request body property "{path_to_phoneNumber}" is compliant with the schema but does not identify a valid phone number
+    When the request "{operationId}" is sent
+    Then the response status code is 404
+    And the response property "$.status" is 404
+    And the response property "$.code" is "IDENTIFIER_NOT_FOUND"
+    And the response property "$.message" contains a user friendly text
 
-    @{feature_identifier}_C02.03_unnecessary_phone_number
-    Scenario: Phone number not to be included when it can be deduced from the access token
-        Given the header "Authorization" is set to a valid access token identifying a phone number
-        And  the request body property "{path_to_phoneNumber}" is set to a valid phone number
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C02.03_unnecessary_phone_number
+  Scenario: Phone number not to be included when it can be deduced from the access token
+    Given the header "Authorization" is set to a valid access token identifying a phone number
+    And  the request body property "{path_to_phoneNumber}" is set to a valid phone number
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "UNNECESSARY_IDENTIFIER"
+    And the response property "$.message" contains a user friendly text
 
-    @{feature_identifier}_C02.04_missing_phone_number
-    Scenario: Phone number not included and cannot be deduced from the access token
-        Given the header "Authorization" is set to a valid access token which does not identify a single phone number
-        And the request body property "{path_to_phoneNumber}" is not included
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "MISSING_IDENTIFIER"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C02.04_missing_phone_number
+  Scenario: Phone number not included and cannot be deduced from the access token
+    Given the header "Authorization" is set to a valid access token which does not identify a single phone number
+    And the request body property "{path_to_phoneNumber}" is not included
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "MISSING_IDENTIFIER"
+    And the response property "$.message" contains a user friendly text
 
     # When the service is only offered to certain type of subscriptions, e.g. IoT, , B2C, etc
-    @{feature_identifier}_C02.05_phone_number_not_supported
-    Scenario: Service not available for the phone number
-        Given that the service is not available for all phone numbers commercialized by the operator
-        And a valid phone number, identified by the token or provided in the request body, for which the service is not applicable
-        When the request "{operationId}" is sent
-        Then the response status code is 422
-        And the response property "$.status" is 422
-        And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
-        And the response property "$.message" contains a user friendly text
+  @{feature_identifier}_C02.05_phone_number_not_supported
+  Scenario: Service not available for the phone number
+    Given that the service is not available for all phone numbers commercialized by the operator
+    And a valid phone number, identified by the token or provided in the request body, for which the service is not applicable
+    When the request "{operationId}" is sent
+    Then the response status code is 422
+    And the response property "$.status" is 422
+    And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
+    And the response property "$.message" contains a user friendly text

--- a/artifacts/testing/event-subscription-template.feature
+++ b/artifacts/testing/event-subscription-template.feature
@@ -1,4 +1,4 @@
-@<xxx>
+  @<xxx>
 Feature: Camara Template Subscriptions API - Operations on subscriptions
 
     CAMARA Commonalities: wip
@@ -135,7 +135,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ######################### Scenario in case initialEvent is managed ##############################
 
-@<xxx>_subscriptions_11_subscription_creation_initial_event
+  @<xxx>_subscriptions_11_subscription_creation_initial_event
   Scenario: Receive initial event notification on creation
     Given the API supports initial events to be sent
     And a valid subscription request body with property "$.config.initialEvent" set to true

--- a/artifacts/testing/sample-implicit-events-template.feature
+++ b/artifacts/testing/sample-implicit-events-template.feature
@@ -2,8 +2,8 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-implicit-events.ya
 
     CAMARA Commonalities: wip
     Additional Common test scenarios for operations defined in sample-implicit-events.yaml.
-    
-    Common test scenarios for operations defined in sample-implicit-events.yaml are already defined in sample-service-template.feature. 
+
+    Common test scenarios for operations defined in sample-implicit-events.yaml are already defined in sample-service-template.feature.
     This feature file includes additional scenarios that can be applied to the operations defined in sample-implicit-events.yaml
 
     NOTES:

--- a/artifacts/testing/sample-service-template.feature
+++ b/artifacts/testing/sample-service-template.feature
@@ -36,7 +36,7 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
     And the path parameter "<ResourceId>" is set by default to a existing value
 
 ############################ Happy Path Scenarios #############################################
-  
+
   # createResource MUST be replaced by applicable operationId for the tested operation
   # schema names MUST be replaced by applicable values for the tested operation
   # Applicable for APIs with device concept
@@ -199,8 +199,8 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
 
 # applicable for operations with request body
 # applicable to properties in the request body which are of type object, and have required properties or minProperties in their value
-@{feature_identifier}_{operationId}_400.04_empty_property
-Scenario Outline: Error response for empty property in request body
+  @{feature_identifier}_{operationId}_400.04_empty_property
+  Scenario Outline: Error response for empty property in request body
     Given the request body property "<required_property>" is set to {}
     When the request "{operationId}" is sent
     Then the response status code is 400
@@ -215,8 +215,8 @@ Scenario Outline: Error response for empty property in request body
       | {value}           |
 
 # applicable for operations with request body
-@{feature_identifier}_{operationId}_400.05_missing_required_property
-Scenario Outline: Error response for missing required property in request body
+  @{feature_identifier}_{operationId}_400.05_missing_required_property
+  Scenario Outline: Error response for missing required property in request body
     Given the request body property "<required_property>" is not included
     When the request "{operationId}" is sent
     Then the response status code is 400


### PR DESCRIPTION
#### What type of PR is this?

* correction
* cleanup

#### What this PR does / why we need it:

Normalizes the common artifacts so their checked-in formatting matches the CAMARA lint configuration:

- adds the proposed root `.gitattributes` policy to keep text files on LF and protect binary formats from conversion
- normalizes the four CRLF artifact files identified in #674 to LF
- fixes the 121 Gherkin indentation findings and 7 trailing-space findings identified in #675

The Gherkin scenarios, steps, examples, and YAML values are unchanged.

#### Which issue(s) this PR fixes:

Fixes #674
Fixes #675

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

This PR depends on #673, which introduces the Artifacts Lint workflow. I validated the combined #673 + this PR state locally with the same `v1-rc` tooling pins:

- yamllint over `artifacts/`: pass
- Spectral over API and notification templates: 0 errors
- gplint over feature templates: 0 errors; 16 expected template warnings remain for #676 to document
- `git diff --ignore-all-space` over all changed artifacts: no content differences
- `git diff --check`: pass

Before this change, gplint reported 144 warnings. The remaining 16 are the 10 duplicate-scenario-name and 6 unused-template-variable warnings described in #676.

#### Changelog input

```
 release-note
- Normalized common artifact line endings to LF and added repository-level Git attributes
- Aligned Gherkin feature template indentation and trailing whitespace with CAMARA lint rules
```

#### Additional documentation

This section can be blank.

```
docs

```
