### PR TITLE
Align notification template with CAMARA lint rules

### DIFF
--- a/artifacts/notification-templates/sample-notification.yaml
+++ b/artifacts/notification-templates/sample-notification.yaml
@@ -18,11 +18,11 @@ externalDocs:
   url: https://github.com/camaraproject/Commonalities
 
 servers:
-  - url: "{apiRoot}"
+  - url: "{sinkRoot}"
     variables:
-      apiRoot:
-        default: http://localhost:9091
-        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
+      sinkRoot:
+        default: https://endpoint.example.com
+        description: Can be any notification server address sent by the client application
 
 tags:
   - name: CAMARA Cloud Event

--- a/artifacts/notification-templates/sample-notification.yaml
+++ b/artifacts/notification-templates/sample-notification.yaml
@@ -21,8 +21,8 @@ servers:
   - url: "{apiRoot}"
     variables:
       apiRoot:
-        default: https://localhost:8080
-        description: Can be any notification server address sent by the client application
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 
 tags:
   - name: CAMARA Cloud Event
@@ -74,3 +74,6 @@ components:
       type: http
       scheme: bearer
       bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Aligns `sample-notification.yaml` with the notification sink semantics described in #677:

- renames the notification server variable from `apiRoot` to `sinkRoot`
- sets its default to `https://endpoint.example.com`, matching the Sink example
- retains the consumer-oriented notification server description
- documents `notificationsBearerAuth` so the security scheme passes the r4 Spectral description rule

#### Which issue(s) this PR fixes:

Fixes #677

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

This PR depends on #673, which introduces the Artifacts Lint workflow. I validated the combined #673 + this PR state locally with the same `v1-rc` tooling pins:

- yamllint over `artifacts/`: pass
- Spectral over API and notification templates: 0 errors, 18 existing warnings, and 0 hints
- targeted Spectral validation for `sample-notification.yaml`: no issue-specific findings
- gplint: 0 errors; its existing formatting warnings are addressed separately by #678
- `git diff --check`: pass

#### Changelog input

```
 release-note
- Model the notification template server as a consumer-provided sink and document bearer authentication
```

#### Additional documentation

This section can be blank.

```
docs

```
