### PR TITLE
Fix remaining gplint findings in the feature templates

### DIFF
--- a/artifacts/testing/event-subscription-template.feature
+++ b/artifacts/testing/event-subscription-template.feature
@@ -147,7 +147,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 ######################### Additional Happy Path Scenarios ##############################
 
   @<xxx>_subscriptions_12_Create_<xxx>_subscription_sync_with_accesstoken_sink_credential
-  Scenario: Create <xxx> subscription (sync creation)
+  Scenario: Create <xxx> subscription (sync creation) with ACCESSTOKEN sinkCredential
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
     Given that subscriptions are created synchronously
@@ -165,7 +165,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.sinkCredential.accessTokenExpiresUtc", if present, is set to the same value of the request property "$.sinkCredential.accessTokenExpiresUtc"
 
   @<xxx>_subscriptions_13_Create_<xxx>_subscription_sync_with_private_jwt_key_sink_credential_out_of_band_provisioning
-  Scenario: Create <xxx> subscription (sync creation)
+  Scenario: Create <xxx> subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, out-of-band provisioning
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may only support out_of_band provisioning
     Given that subscriptions are created synchronously
@@ -178,7 +178,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
 
   @<xxx>_subscriptions_14_Create_<xxx>_subscription_sync_with_private_jwt_key_sink_credential_in_band_provisioning
-  Scenario: Create <xxx> subscription (sync creation)
+  Scenario: Create <xxx> subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, in-band provisioning
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may additionally support in_band provisioning
     Given that subscriptions are created synchronously
@@ -196,7 +196,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
   @<xxx>_subscriptions_15_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_access_token_sink_credential_returned
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
-  Scenario: Get a subscription based on existing subscription-id.
+  Scenario: Get a subscription based on existing subscription-id, with ACCESSTOKEN sinkCredential returned.
     Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
     When the request "retrieve<xxx>Subscription" is sent
     Then the response code is 200
@@ -209,7 +209,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
   @<xxx>_subscriptions_16_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_private_jwt_key_sink_credential_returned
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
   # Mainly applicable for in-band provisioning of PRIVATE_JWT_KEY mode for a given subscription
-  Scenario: Get a subscription based on existing subscription-id.
+  Scenario: Get a subscription based on existing subscription-id, with PRIVATE_JWT_KEY sinkCredential returned.
     Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
     When the request "retrieve<xxx>Subscription" is sent
     Then the response code is 200

--- a/artifacts/testing/event-subscription-template.feature
+++ b/artifacts/testing/event-subscription-template.feature
@@ -1,11 +1,11 @@
-  @<xxx>
+  @{xxx}
 Feature: Camara Template Subscriptions API - Operations on subscriptions
 
     CAMARA Commonalities: wip
 
   # This feature file is to be used by CAMARA subproject when an event subscription resource is provided.
-  # We use <xxx> as the subscription resource prefix.
-  # We use <x> as the event version.
+  # We use {xxx} as the subscription resource prefix.
+  # We use {x} as the event version.
   #
   # If the subscription leverages the 'device' object the following indication must be present:
   #    Implementation indications:
@@ -15,16 +15,16 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
   #        A sink-url identified as "callbackUrl", which receives notifications
   #        + Add here the specific testing asset(s) required to test the API
   #
-  # References to OAS spec schemas refer to schemas specified in <xxx>-subscriptions.yaml
-  # References to schemas starting with the # symbol are JSON Pointers from the root of the OAS document: <xxx>-subscriptions.yaml, Schema names are aligned with the sample-service-subscriptions.yaml template.
+  # References to OAS spec schemas refer to schemas specified in {xxx}-subscriptions.yaml
+  # References to schemas starting with the # symbol are JSON Pointers from the root of the OAS document: {xxx}-subscriptions.yaml, Schema names are aligned with the sample-service-subscriptions.yaml template.
   #
   # IMPORTANT:
   # 1/ This file must be completed with the test cases specific to the subscription type managed by the API.
   # 2/ Specific Subscription error scenarios when the Device object is used must be added. These scenarios are available in CAMARA Github.   ################
   #    source: Commonalities/artifacts/testing
 
-  Background: Common <xxx> Subscriptions setup
-    Given the resource "{apiroot}/<xxx>-subscriptions/vwip/" as <xxx> base-url
+  Background: Common {xxx} Subscriptions setup
+    Given the resource "{apiroot}/{xxx}-subscriptions/vwip/" as {xxx} base-url
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
 
@@ -32,42 +32,42 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 # Note: Depending on the API managed personal data specific scenario update may be require to specify use of 2-legs or 3-legs access token.
 
-  @<xxx>_subscriptions_01_Create_<xxx>_subscription_sync
-  Scenario: Create <xxx> subscription (sync creation)
+  @{xxx}_subscriptions_01_Create_{xxx}_subscription_sync
+  Scenario: Create {xxx} subscription (sync creation)
   # Some implementations may only support asynchronous subscription creation
     Given that subscriptions are created synchronously
     And a valid subscription request body
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
 
-  @<xxx>_subscriptions_02_Create_<xxx>_subscription_async
-  Scenario:  Create <xxx> subscription (async creation)
+  @{xxx}_subscriptions_02_Create_{xxx}_subscription_async
+  Scenario:  Create {xxx} subscription (async creation)
   # Some implementations may only support synchronous subscription creation
     Given that subscriptions are created asynchronously
     And a valid subscription request body
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 202
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync"
 
-  @<xxx>_subscriptions_03_subscription_creation_event_validation
+  @{xxx}_subscriptions_03_subscription_creation_event_validation
   Scenario: Receive notification for subscription-started event on creation
     Given a valid subscription request body
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201 or 202
     And event notification "subscription-started" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionStarted"
-    And type="org.camaraproject.<xxx>-subscriptions.v<x>.subscription-started"
+    And type="org.camaraproject.{xxx}-subscriptions.v{x}.subscription-started"
     And the response property "$.initiationReason" is "SUBSCRIPTION_CREATED"
 
-  @<xxx>_subscriptions_04_Operation_to_retrieve_list_of_subscriptions_when_no_records
-  Scenario: Get a list of <xxx> subscriptions when no subscriptions available
-    Given a client without <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent
+  @{xxx}_subscriptions_04_Operation_to_retrieve_list_of_subscriptions_when_no_records
+  Scenario: Get a list of {xxx} subscriptions when no subscriptions available
+    Given a client without {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -75,10 +75,10 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.subscriptions" is an empty array
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
 
-  @<xxx>_subscriptions_05_Operation_to_retrieve_list_of_subscriptions
+  @{xxx}_subscriptions_05_Operation_to_retrieve_list_of_subscriptions
   Scenario: Get a list of subscriptions
-    Given a client with <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent
+    Given a client with {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -86,68 +86,68 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And each item in the response body property "$.subscriptions" complies with the OAS schema at "#/components/schemas/Subscription"
     And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
 
-  @<xxx>_subscriptions_06_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id
+  @{xxx}_subscriptions_06_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id
   Scenario: Get a subscription based on existing subscription-id.
-    Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    Given the path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
 
-  @<xxx>_subscriptions_07_Operation_to_delete_subscription_based_on_an_existing_subscription-id
+  @{xxx}_subscriptions_07_Operation_to_delete_subscription_based_on_an_existing_subscription-id
   Scenario: Delete a subscription based on existing subscription-id.
-    Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "delete<xxx>Subscription" is sent
+    Given the path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "delete{xxx}Subscription" is sent
     Then the response code is 202 or 204
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And if the response property "$.status" is 204 then the response body is not available
     And if the response property "$.status" is 202 then the response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync"
 
-  @<xxx>_subscriptions_08_subscription_ends_on_expiry
+  @{xxx}_subscriptions_08_subscription_ends_on_expiry
   Scenario: Receive notification for subscription-ended event on expiry
-    Given an existing <xxx> subscription with some value for the property "expiresAt" in the near future
+    Given an existing {xxx} subscription with some value for the property "expiresAt" in the near future
     When the subscription is expired
     Then the event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
-    And type="org.camaraproject.<xxx>-subscriptions.v<x>.subscription-ended"
+    And type="org.camaraproject.{xxx}-subscriptions.v{x}.subscription-ended"
     And the response property "$.terminationReason" is "SUBSCRIPTION_EXPIRED"
 
-  @<xxx>_subscriptions_09_subscription_ends_on_max_events
+  @{xxx}_subscriptions_09_subscription_ends_on_max_events
   Scenario: Receive notification for subscription-ended event on max events reached
-    Given an existing <xxx> subscription with the property "config.subscriptionMaxEvents" set to 1
+    Given an existing {xxx} subscription with the property "config.subscriptionMaxEvents" set to 1
     When the event subscribed occurs
-    Then event notification "<event-type>" is received on callback-url
+    Then event notification "{event-type}" is received on callback-url
     And event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
-    And type="org.camaraproject.<xxx>-subscriptions.v<x>.subscription-ended"
+    And type="org.camaraproject.{xxx}-subscriptions.v{x}.subscription-ended"
     And the response property "$.terminationReason" is "MAX_EVENTS_REACHED"
 
-  @<xxx>_subscriptions_10_subscription_delete_event_validation
+  @{xxx}_subscriptions_10_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ended event on deletion
-    Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "delete<xxx>Subscription" is sent
+    Given the path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "delete{xxx}Subscription" is sent
     Then the response code is 202 or 204
     And event notification "subscription-ended" is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/EventSubscriptionEnded"
-    And type="org.camaraproject.<xxx>-subscriptions.v<x>.subscription-ended"
+    And type="org.camaraproject.{xxx}-subscriptions.v{x}.subscription-ended"
     And the response property "$.terminationReason" is "SUBSCRIPTION_DELETED"
 
 ######################### Scenario in case initialEvent is managed ##############################
 
-  @<xxx>_subscriptions_11_subscription_creation_initial_event
+  @{xxx}_subscriptions_11_subscription_creation_initial_event
   Scenario: Receive initial event notification on creation
     Given the API supports initial events to be sent
     And a valid subscription request body with property "$.config.initialEvent" set to true
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201 or 202
     And an event notification of the subscribed type is received on callback-url
     And notification body complies with the OAS schema at "#/components/schemas/CloudEvent"
 
 ######################### Additional Happy Path Scenarios ##############################
 
-  @<xxx>_subscriptions_12_Create_<xxx>_subscription_sync_with_accesstoken_sink_credential
-  Scenario: Create <xxx> subscription (sync creation) with ACCESSTOKEN sinkCredential
+  @{xxx}_subscriptions_12_Create_{xxx}_subscription_sync_with_accesstoken_sink_credential
+  Scenario: Create {xxx} subscription (sync creation) with ACCESSTOKEN sinkCredential
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
     Given that subscriptions are created synchronously
@@ -156,7 +156,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the request property "$.sinkCredential.accessTokenType" is set to "bearer"
     And the request property "$.sinkCredential.accessToken" is set to a valid access token
     And the request property "$.sinkCredential.accessTokenExpiresUtc" is set to a valid expiry date in the future
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -164,21 +164,21 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.sinkCredential.credentialType", if present, is set to value "ACCESSTOKEN"
     And the response body property "$.sinkCredential.accessTokenExpiresUtc", if present, is set to the same value of the request property "$.sinkCredential.accessTokenExpiresUtc"
 
-  @<xxx>_subscriptions_13_Create_<xxx>_subscription_sync_with_private_jwt_key_sink_credential_out_of_band_provisioning
-  Scenario: Create <xxx> subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, out-of-band provisioning
+  @{xxx}_subscriptions_13_Create_{xxx}_subscription_sync_with_private_jwt_key_sink_credential_out_of_band_provisioning
+  Scenario: Create {xxx} subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, out-of-band provisioning
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may only support out_of_band provisioning
     Given that subscriptions are created synchronously
     And a valid subscription request body
     And the request property "$.sinkCredential.credentialType" is set to "PRIVATE_JWT_KEY"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/Subscription"
 
-  @<xxx>_subscriptions_14_Create_<xxx>_subscription_sync_with_private_jwt_key_sink_credential_in_band_provisioning
-  Scenario: Create <xxx> subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, in-band provisioning
+  @{xxx}_subscriptions_14_Create_{xxx}_subscription_sync_with_private_jwt_key_sink_credential_in_band_provisioning
+  Scenario: Create {xxx} subscription (sync creation) with PRIVATE_JWT_KEY sinkCredential, in-band provisioning
   # Some implementations may only support asynchronous subscription creation
   # Some implementations may additionally support in_band provisioning
     Given that subscriptions are created synchronously
@@ -186,7 +186,7 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the request property "$.sinkCredential.credentialType" is set to "PRIVATE_JWT_KEY"
     And the request property "$.sinkCredential.clientId" is set to a valid value
     And the request property "$.sinkCredential.tokenUri" is set to a valid value
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -194,11 +194,11 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.sinkCredential.credentialType" is set to value "PRIVATE_JWT_KEY"
     And the response body property "$.sinkCredential.jwksUri" is set to a valid value
 
-  @<xxx>_subscriptions_15_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_access_token_sink_credential_returned
+  @{xxx}_subscriptions_15_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_access_token_sink_credential_returned
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
   Scenario: Get a subscription based on existing subscription-id, with ACCESSTOKEN sinkCredential returned.
-    Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    Given the path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -206,12 +206,12 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.sinkCredential.credentialType", if present, is set to value "ACCESSTOKEN"
     And the response body property "$.sinkCredential.accessTokenExpiresUtc", if present, is set to the same value of the request property "$.sinkCredential.accessTokenExpiresUtc"
 
-  @<xxx>_subscriptions_16_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_private_jwt_key_sink_credential_returned
+  @{xxx}_subscriptions_16_Operation_to_retrieve_subscription_based_on_an_existing_subscription-id_private_jwt_key_sink_credential_returned
   # Some implementations may decide to not return the sinkCredential in the response (data minimization principle)
   # Mainly applicable for in-band provisioning of PRIVATE_JWT_KEY mode for a given subscription
   Scenario: Get a subscription based on existing subscription-id, with PRIVATE_JWT_KEY sinkCredential returned.
-    Given the path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    Given the path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -222,100 +222,100 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 ########################### Error response scenarios ############################################
 ########################### Subscription creation scenarios #####################################
 
-  @<xxx>_subscriptions_20_creation_<xxx>_subscription_with_invalid_parameter
-  Scenario:  Create <xxx> subscription with invalid parameter
+  @{xxx}_subscriptions_20_creation_{xxx}_subscription_with_invalid_parameter
+  Scenario:  Create {xxx} subscription with invalid parameter
     Given the request body is not compliant with the schema "#/components/schemas/SubscriptionRequest"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_21_creation_of_subscription_with_expiry_time_in_past
+  @{xxx}_subscriptions_21_creation_of_subscription_with_expiry_time_in_past
   Scenario: Expiry time in past
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And request body property "$.config.subscriptionExpireTime" in the past
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscription_22_creation_with_invalid_eventType
+  @{xxx}_subscription_22_creation_with_invalid_eventType
   Scenario: Subscription creation with invalid event type
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request body property "$.types" is set to invalid value
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscription_23_invalid_protocol
+  @{xxx}_subscription_23_invalid_protocol
   Scenario: Subscription creation with invalid protocol
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request property "$.protocol" is not set to "HTTP"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response property "$.status" is 400
     And the response property "$.code" is "INVALID_PROTOCOL"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscription_24_invalid_credential
+  @{xxx}_subscription_24_invalid_credential
   Scenario: Subscription creation with invalid credential
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request property "$.protocol" is set to "HTTP"
     And the request property "$.sinkCredential.credentialType" is not set to "ACCESSTOKEN" and is not set to "PRIVATE_KEY_JWT"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response property "$.status" is 400
     And the response property "$.code" is "INVALID_CREDENTIAL"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscription_25_invalid_token
+  @{xxx}_subscription_25_invalid_token
   Scenario: Subscription creation with invalid token
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request property "$.protocol" is set to "HTTP"
     And the request property "$.sinkCredential.credentialType" is set to "ACCESSTOKEN"
     And the request property "$.sinkCredential.accessTokenType" is not set to "bearer"
     And the request property "$.sinkCredential.accessToken" is valued with a valid value
     And the request property "$.sinkCredential.accessTokenExpiresUtc" is valued with a valid value
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response property "$.status" is 400
     And the response property "$.code" is "INVALID_TOKEN"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscription_26_invalid_url
+  @{xxx}_subscription_26_invalid_url
   Scenario: Subscription creation with invalid url
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request property "$.protocol" is set to "HTTP"
     And the request property "$.sink" is set to "invalid-url"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response property "$.status" is 400
     And the response property "$.code" is "INVALID_SINK"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_27_no_authorization_header_for_create_subscription
+  @{xxx}_subscriptions_27_no_authorization_header_for_create_subscription
   Scenario: No Authorization header for create subscription
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And the request does not include the "Authorization" header
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_28_expired_access_token_for_create_subscription
+  @{xxx}_subscriptions_28_expired_access_token_for_create_subscription
   Scenario: Expired access token for create subscription
-    Given a valid <xxx> subscription request body and header "Authorization" is expired
-    When the request "create<xxx>Subscription" is sent
+    Given a valid {xxx} subscription request body and header "Authorization" is expired
+    When the request "create{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_29_invalid_access_token_for_create_subscription
+  @{xxx}_subscriptions_29_invalid_access_token_for_create_subscription
   Scenario: Invalid access token for create subscription
-    Given a valid <xxx> subscription request body
+    Given a valid {xxx} subscription request body
     And header "Authorization" set to an invalid access token
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -323,40 +323,40 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ########################### Subscription retrieval scenarios #####################################
 
-  @<xxx>_subscriptions_30_no_authorization_header_for_get_subscription
+  @{xxx}_subscriptions_30_no_authorization_header_for_get_subscription
   Scenario: No Authorization header for get subscription
     Given header "Authorization" is not present
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_31_expired_access_token_for_get_subscription
+  @{xxx}_subscriptions_31_expired_access_token_for_get_subscription
   Scenario: Expired access token for get subscription
     Given the header "Authorization" is set to expired token
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_32_invalid_access_token_for_get_subscription
+  @{xxx}_subscriptions_32_invalid_access_token_for_get_subscription
   Scenario: Invalid access token for get subscription
     Given the header "Authorization" set to an invalid access token
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_33_get_unknown_<xxx>_subscription_for_a_device
-  Scenario:  Get method for <xxx> subscription with subscription-id unknown to the system
+  @{xxx}_subscriptions_33_get_unknown_{xxx}_subscription_for_a_device
+  Scenario:  Get method for {xxx} subscription with subscription-id unknown to the system
     Given the path parameter "subscriptionId" is set to a value not corresponding to any existing subscription
-    When the request "retrieve<xxx>Subscription" is sent
+    When the request "retrieve{xxx}Subscription" is sent
     Then the response  code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
@@ -364,28 +364,28 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ########################### Subscription list retrieval scenarios #####################################
 
-  @<xxx>_subscriptions_40_no_authorization_header_for_list_subscription
+  @{xxx}_subscriptions_40_no_authorization_header_for_list_subscription
   Scenario: No Authorization header for list subscription
     Given header "Authorization" is not present
-    When the request "retrieve<xxx>SubscriptionList" is sent
+    When the request "retrieve{xxx}SubscriptionList" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_41_expired_access_token_for_list_subscription
+  @{xxx}_subscriptions_41_expired_access_token_for_list_subscription
   Scenario: Expired access token for list subscription
     Given the header "Authorization" is set to expired token
-    When the request "retrieve<xxx>SubscriptionList" is sent
+    When the request "retrieve{xxx}SubscriptionList" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_42_invalid_access_token_for_list_subscription
+  @{xxx}_subscriptions_42_invalid_access_token_for_list_subscription
   Scenario: Invalid access token for list subscription
     Given the header "Authorization" set to an invalid access token
-    When the request "retrieve<xxx>SubscriptionList" is sent
+    When the request "retrieve{xxx}SubscriptionList" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
@@ -393,41 +393,41 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ########################### Subscription deletion scenarios #####################################
 
-  @<xxx>_subscriptions_50_no_authorization_header_for_delete_subscription
+  @{xxx}_subscriptions_50_no_authorization_header_for_delete_subscription
   Scenario: No Authorization header for delete subscription
     Given header "Authorization" is set without a token
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "delete<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "delete{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_51_expired_access_token_for_delete_subscription
+  @{xxx}_subscriptions_51_expired_access_token_for_delete_subscription
   Scenario: Expired access token for delete subscription
     Given header "Authorization" is set with an expired token
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "delete<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "delete{xxx}Subscription" is sent
     Then the response status code is 401
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_52_invalid_access_token_for_delete_subscription
+  @{xxx}_subscriptions_52_invalid_access_token_for_delete_subscription
   Scenario: Invalid access token for delete subscription
     Given header "Authorization" set to an invalid access token
-    And path parameter "subscriptionId" is set to the identifier of an existing <xxx> subscription
-    When the request "delete<xxx>Subscription" is sent
+    And path parameter "subscriptionId" is set to the identifier of an existing {xxx} subscription
+    When the request "delete{xxx}Subscription" is sent
     Then the response status code is 401
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 401
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_53_delete_invalid_<xxx>_subscription
-  Scenario:  Delete <xxx> subscription with subscription-id unknown to the system
+  @{xxx}_subscriptions_53_delete_invalid_{xxx}_subscription
+  Scenario:  Delete {xxx} subscription with subscription-id unknown to the system
     Given the path parameter "subscriptionId" is set to a value not corresponding to any existing subscription
-    When the request "delete<xxx>Subscription" is sent
+    When the request "delete{xxx}Subscription" is sent
     Then the response code is 404
     And the response property "$.status" is 404
     And the response property "$.code" is "NOT_FOUND"
@@ -435,12 +435,12 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ########Specific Subscription error scenario if multi-event is not permitted ################
 
-  @<xxx>_subscriptions_60_creation_with_unsupported_multiple_event_type
+  @{xxx}_subscriptions_60_creation_with_unsupported_multiple_event_type
   Scenario: Multi event subscription not supported
     Given the API provider only allows one event to be subscribed per subscription request
     And a valid subscription request body
     And the request body property "$.types" is set to an array with 2 valid items
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED"
@@ -448,12 +448,12 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 ########Specific Subscription error scenario if Private JWT Key is not pre-configured ################
 
-  @<xxx>_subscriptions_61_creation_with_private_jwt_key_not_configured
+  @{xxx}_subscriptions_61_creation_with_private_jwt_key_not_configured
   Scenario: Private JWT Key not configured for subscription creation
     Given the API provider requires the use of a Private JWT key mechanism for subscription creation authentication
     And the Private JWT key mechanism is not pre-configured in the environment
     And a valid subscription request body with the property "$.sinkCredential.credentialType" set to "PRIVATE_KEY_JWT"
-    When the request "create<xxx>Subscription" is sent
+    When the request "create{xxx}Subscription" is sent
     Then the response code is 422
     And the response property "$.status" is 422
     And the response property "$.code" is "PRIVATE_KEY_JWT_NOT_CONFIGURED"
@@ -463,10 +463,10 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
 
 # Check applicability of below tests according to the nature of the API initiative Use Cases
 
-  @<xxx>_subscriptions_70_pagination_default_values
+  @{xxx}_subscriptions_70_pagination_default_values
   Scenario: Subscription list pagination with default values for page and perPage
-    Given an API client with more than 20 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent without setting query parameters "page" and "perPage"
+    Given an API client with more than 20 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent without setting query parameters "page" and "perPage"
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -477,10 +477,10 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.pagination.page" is 1
     And the response body property "$.pagination.perPage" is 20
 
-  @<xxx>_subscriptions_71_pagination_custom_values
+  @{xxx}_subscriptions_71_pagination_custom_values
   Scenario: Subscription list pagination with custom values for page and perPage
-    Given an API client with more than 40 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent with query parameters "page" set to 1 and "perPage" set to 20
+    Given an API client with more than 40 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent with query parameters "page" set to 1 and "perPage" set to 20
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -495,10 +495,10 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.pagination.totalPages", if present, is greater than 2
     And the response body property "$.pagination.totalCount", if present, is greater than 40
 
-  @<xxx>_subscriptions_72_pagination_middle_page
+  @{xxx}_subscriptions_72_pagination_middle_page
   Scenario: Subscription list pagination fetching a middle page of the list
-    Given an API client with more than 40 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent with query parameters "page" set to 2 and "perPage" set to 20
+    Given an API client with more than 40 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent with query parameters "page" set to 2 and "perPage" set to 20
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -513,10 +513,10 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.pagination.totalPages", if present, is greater than 2
     And the response body property "$.pagination.totalCount", if present, is greater than 40
 
-  @<xxx>_subscriptions_73_pagination_last_page
+  @{xxx}_subscriptions_73_pagination_last_page
   Scenario: Subscription list pagination fetching the last page of the list
-    Given an API client with more than 40 and less than 60 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent with query parameters "page" set to 3 and "perPage" set to 20
+    Given an API client with more than 40 and less than 60 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent with query parameters "page" set to 3 and "perPage" set to 20
     Then the response code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
@@ -531,19 +531,19 @@ Feature: Camara Template Subscriptions API - Operations on subscriptions
     And the response body property "$.pagination.totalPages", if present, is 3
     And the response body property "$.pagination.totalCount", if present, is greater than 40 and less than 60
 
-  @<xxx>_subscriptions_74_pagination_invalid_page_parameter
+  @{xxx}_subscriptions_74_pagination_invalid_page_parameter
   Scenario: Subscription list pagination with invalid value for page parameter
-    Given an API client with more than 20 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent with query parameter "page" set to any value less than 1 and "perPage" set to 20
+    Given an API client with more than 20 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent with query parameter "page" set to any value less than 1 and "perPage" set to 20
     Then the response code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
 
-  @<xxx>_subscriptions_75_pagination_invalid_perPage_parameter
+  @{xxx}_subscriptions_75_pagination_invalid_perPage_parameter
   Scenario: Subscription list pagination with invalid value for perPage parameter
-    Given an API client with more than 20 <xxx> subscriptions created
-    When the request "retrieve<xxx>SubscriptionList" is sent with query parameter "page" set to 1 and "perPage" set to any value outside the range [1-100]
+    Given an API client with more than 20 {xxx} subscriptions created
+    When the request "retrieve{xxx}SubscriptionList" is sent with query parameter "page" set to 1 and "perPage" set to any value outside the range [1-100]
     Then the response code is 400
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"

--- a/artifacts/testing/sample-implicit-events-template.feature
+++ b/artifacts/testing/sample-implicit-events-template.feature
@@ -26,18 +26,18 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-implicit-events.ya
 ############################ Happy Path Scenarios #############################################
 
   # Replace ... in the lastest sentence by any type of applicable validation for the property
-  @{feature_identifier}_{operationId}_xx_event_notification
-  Scenario: Event is received if the sink was provided and "<Resource>" lifecycle faces an update
-    Given an existing "<Resource>" created by operation "{operationId}" with provided values for "sink" and "sinkCredential", with property "$.sinkCredential.credentialType" set to "ACCESSTOKEN"
-    And the path parameter "<ResourceId>" is set to the value for that "<Resource>"
+  @{feature_identifier}_{operationId}_2xx_event_notification
+  Scenario: Event is received if the sink was provided and "{Resource}" lifecycle faces an update
+    Given an existing "{Resource}" created by operation "{operationId}" with provided values for "sink" and "sinkCredential", with property "$.sinkCredential.credentialType" set to "ACCESSTOKEN"
+    And the path parameter "{ResourceId}" is set to the value for that "{Resource}"
     When the request "{operationId}" is sent
-    Then the response status code is 2<xx>
+    Then the response status code is 2{xx}
     And an event is received at the address of the "$.sink" provided for "{operationId}"
     And the event header "Authorization" is set to "Bearer " + the value of the property "$.sinkCredential.accessToken" provided for "{operationId}"
     And the event header "Content-Type" is set to "application/cloudevents+json"
     And the event body complies with the OAS schema at "#/components/schemas/ApiNotificationEvent"
     # Additionally any event body has to comply with some constraints beyond the schema compliance
-    And the event body property "$.<property>" is ...
+    And the event body property "$.{property}" is ...
 
 ############################ Error Scenarios #############################################
 

--- a/artifacts/testing/sample-service-template.feature
+++ b/artifacts/testing/sample-service-template.feature
@@ -20,7 +20,7 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   #
   # References to OAS spec schemas refer to schemas specified in {apiname}.yaml
 
-  Background: Common "<operationId>" setup
+  Background: Common "{operationId}" setup
     Given an environment at "apiRoot"
     # Clause for createResource and listResources operations
     And the resource "/{apiname}/v{version}/{resources}"
@@ -31,9 +31,9 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
     # Properties not explicitly overwritten in the Scenarios can take any values compliant with the schema, clause only for createResource (i.e. only for POST/PUT operations in general)
-    And the request body is set by default to a request body compliant with the schema at "#/components/schemas/<createResource>"
+    And the request body is set by default to a request body compliant with the schema at "#/components/schemas/{createResource}"
     # Clause for getResource and deleteResource operations
-    And the path parameter "<ResourceId>" is set by default to a existing value
+    And the path parameter "{ResourceId}" is set by default to a existing value
 
 ############################ Happy Path Scenarios #############################################
 
@@ -41,18 +41,18 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # schema names MUST be replaced by applicable values for the tested operation
   # Applicable for APIs with device concept
   @{feature_identifier}_{createResource}_01_generic_success_scenario
-  Scenario Outline: Common validations for any success scenario
+  Scenario Outline: Common validations for any success scenario with device concept
     # Valid testing device and default request body compliant with the schema
     Given a valid testing device supported by the service, identified by the token or provided in the request body
     # Several clauses for request body property may apply depending on the operation
     And the request body property "$.{requestProperty}" is set to a valid {placeholder_suitable_text}
-    And the request body is compliant with the schema at "#/components/schemas/<createResource>"
-    When the request "<createResource>" is sent
+    And the request body is compliant with the schema at "#/components/schemas/{createResource}"
+    When the request "{createResource}" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "#/components/schemas/<Resource>"
+    And the response body complies with the OAS schema at "#/components/schemas/{Resource}"
     # Additionally, in case any success response has to comply with some constraints beyond the schema compliance
     And the response property "<property>" matches the rule: <condition>
 
@@ -64,18 +64,18 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # schema names MUST be replaced by applicable values for the tested operation
   # Applicable for APIs with phoneNumber concept
   @{feature_identifier}_{createResource}_01_generic_success_scenario
-  Scenario Outline: Common validations for any success scenario
+  Scenario Outline: Common validations for any success scenario with phoneNumber concept
     # Valid testing phone number and default request body compliant with the schema
     Given a valid testing phone number supported by the service, identified by the token or provided in the request body
     # Several clauses for request body property may apply depending on the operation
     And the request body property "$.{requestProperty}" is set to a valid {placeholder_suitable_text}
-    And the request body is compliant with the schema at "#/components/schemas/<createResource>"
-    When the request "<createResource>" is sent
+    And the request body is compliant with the schema at "#/components/schemas/{createResource}"
+    When the request "{createResource}" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "#/components/schemas/<Resource>"
+    And the response body complies with the OAS schema at "#/components/schemas/{Resource}"
     # Additionally, in case any success response has to comply with some constraints beyond the schema compliance
     And the response property "<property>" matches the rule: <condition>
 
@@ -87,17 +87,17 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # schema names MUST be replaced by applicable values for the tested operation
   # Applicable for APIs that does not own device nor phoneNumber concept
   @{feature_identifier}_{createResource}_01_generic_success_scenario
-  Scenario Outline: Common validations for any success scenario
+  Scenario Outline: Common validations for any success scenario without device nor phoneNumber concept
     Given the request body property "$.{requestProperty}" is set to a valid {placeholder_suitable_text}
     # Several clauses for request body property may apply depending on the operation
     And the request body property "$.{requestProperty}" is set to a valid {placeholder_suitable_text}
-    And the request body is compliant with the schema at "#/components/schemas/<createResource>"
-    When the request "<createResource>" is sent
+    And the request body is compliant with the schema at "#/components/schemas/{createResource}"
+    When the request "{createResource}" is sent
     Then the response status code is 201
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has the same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "#/components/schemas/<Resource>"
+    And the response body complies with the OAS schema at "#/components/schemas/{Resource}"
     # Additionally, in case any success response has to comply with some constraints beyond the schema compliance
     And the response property "<property>" matches the rule: <condition>
 
@@ -109,21 +109,21 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # Resource MUST be replaced by the applicable resource for the tested operation
   # schema names MUST be replaced by applicable values for the tested operation
   @{feature_identifier}_{listResources}_01_generic_success_scenario
-  Scenario: Common validations for any success scenario
-    Given at least an existing "<Resource>" created by operation "{operationId}"
-    When the request "<listResources>" is sent
+  Scenario: Common validations for any success scenario for {listResources}
+    Given at least an existing "{Resource}" created by operation "{operationId}"
+    When the request "{listResources}" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body is an array whose items comply with the OAS schema at "#/components/schemas/<Resource>"
+    And the response body is an array whose items comply with the OAS schema at "#/components/schemas/{Resource}"
 
   # listResources MUST be replaced by applicable operationId for the tested operation
   # Resources MUST be replaced by the applicable resource (in plural) for the tested operation
   @{feature_identifier}_{listResources}_02_empty_response
   Scenario: No existing {Resources}
     Given no {Resources} have been created by operation "{operationId}"
-    When the request "<listResources>" is sent
+    When the request "{listResources}" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -133,23 +133,23 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # Resource MUST be replaced by the applicable resource for the tested operation
   # schema names MUST be replaced by applicable values for the tested operation
   @{feature_identifier}_{getResource}_01_generic_success_scenario
-  Scenario: Common validations for any success scenario
-    Given an existing "<Resource>" created by operation "{operationId}"
-    And the path parameter "<ResourceId>" is set to the value of the identifier for that "<Resource>"
-    When the request "<getResource>" is sent
+  Scenario: Common validations for any success scenario for {getResource}
+    Given an existing "{Resource}" created by operation "{operationId}"
+    And the path parameter "{ResourceId}" is set to the value of the identifier for that "{Resource}"
+    When the request "{getResource}" is sent
     Then the response status code is 200
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
     # The response has to comply with the generic response schema which is part of the spec
-    And the response body complies with the OAS schema at "#/components/schemas/<Resource>"
+    And the response body complies with the OAS schema at "#/components/schemas/{Resource}"
 
   # deleteResource MUST be replaced by applicable operationId for the tested operation
   # Resource MUST be replaced by the applicable resource for the tested operation
   @{feature_identifier}_{deleteResource}_01_generic_success_scenario
-  Scenario: Common validations for any success scenario
-    Given an existing "<Resource>" created by operation "{operationId}"
-    And the path parameter "<ResourceId>" is set to the value of the identifier for that "<Resource>"
-    When the request "<deleteResource>" is sent
+  Scenario: Common validations for any success scenario for {deleteResource}
+    Given an existing "{Resource}" created by operation "{operationId}"
+    And the path parameter "{ResourceId}" is set to the value of the identifier for that "{Resource}"
+    When the request "{deleteResource}" is sent
     Then the response status code is 204
     And the response header "Content-Type" is "application/json"
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -162,7 +162,7 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # schema names MUST be replaced by applicable values for the tested operation
   @{feature_identifier}_{operationId}_400.01_schema_not_compliant
   Scenario: Invalid Argument. Generic Syntax Exception
-    Given the request body is included but is not compliant with the schema at "#/components/schemas/<requestSchema>"
+    Given the request body is included but is not compliant with the schema at "#/components/schemas/{requestSchema}"
     When the request "{operationId}" is sent
     Then the response status code is 400
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -282,7 +282,7 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
 
   @{feature_identifier}_{operationId}_403.01_missing_access_token_scope
   Scenario: Missing access token scope
-    Given the header "Authorization" is set to an access token that does not include scope "<scope>"
+    Given the header "Authorization" is set to an access token that does not include scope "{scope}"
     When the request "{operationId}" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -292,9 +292,9 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
     And the response property "$.message" contains a user friendly text
 
   @{feature_identifier}_{operationId}_403.02_api_client_token_mismatch
-  Scenario: "<Resource>" not created by the API client given in the access token
+  Scenario: "{Resource}" not created by the API client given in the access token
     # To test this, a token has to be obtained for a different client
-    Given the header "Authorization" is set to a valid access token emitted to an API client which did not have rights to access/manage the "<Resource>"
+    Given the header "Authorization" is set to a valid access token emitted to an API client which did not have rights to access/manage the "{Resource}"
     When the request "{operationId}" is sent
     Then the response status code is 403
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -306,8 +306,8 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # Generic 404 Errors
 
   @{feature_identifier}_{operationId}_404.01_not_found
-  Scenario: non-existing "<ResourceId>"
-    Given the path parameter "<ResourceId>" is set to a random UUID
+  Scenario: non-existing "{ResourceId}"
+    Given the path parameter "{ResourceId}" is set to a random UUID
     When the request "{operationId}" is sent
     Then the response status code is 404
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -319,12 +319,12 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
   # Generic 409 Errors
 
   # This scenario applies to operations that create/manage a resource with a unique property (e.g. name) and the service does not allow multiple resources with the same value for that property, even if they have different identifiers. If the service allows multiple resources with the same value for that property, this scenario would not apply.
-  # unique property and Resource MUST be replaced by applicable values for the tested operation
+  # unique_property and Resource MUST be replaced by applicable values for the tested operation
   @{feature_identifier}_{operationId}_409.01_duplicated_resource
-  Scenario: Conflict due to existing "<Resource>"
-    Given a "<Resource>" already exists with the same "<unique property>" as the one in the request body
+  Scenario: Conflict due to existing "{Resource}"
+    Given a "{Resource}" already exists with the same "{unique_property}" as the one in the request body
     # Additional clauses may exist according to API nature
-    And the request body property "$.<requestProperty>" is set to a value already used in another successful "<Resource>" request
+    And the request body property "$.{requestProperty}" is set to a value already used in another successful "{Resource}" request
     When the request "{operationId}" is sent
     Then the response status code is 409
     And the response header "x-correlator" has same value as the request header "x-correlator"
@@ -335,8 +335,8 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
 
   # Resource MUST be replaced by the applicable resource for the tested operation
   @{feature_identifier}_{operationId}_409.02_request_aborted
-  Scenario: Conflict due to "<Resource>" being modified
-    Given a "<Resource>" is being modified by another request and the service does not allow concurrent modifications for the same resource
+  Scenario: Conflict due to "{Resource}" being modified
+    Given a "{Resource}" is being modified by another request and the service does not allow concurrent modifications for the same resource
     # Additional clauses may exist according to API nature
     When the request "{operationId}" is sent
     Then the response status code is 409
@@ -348,8 +348,8 @@ Feature: CAMARA Template Artifact - Test scenarios for sample-service.yaml
 
   # Resource MUST be replaced by the applicable resource for the tested operation
   @{feature_identifier}_{operationId}_409.03_incompatible_state
-  Scenario: Conflict due to "<Resource>" (target or referenced) is in incompatible state for the requested operation
-    Given the "<Resource>" is in an invalid state for management
+  Scenario: Conflict due to "{Resource}" (target or referenced) is in incompatible state for the requested operation
+    Given the "{Resource}" is in an invalid state for management
     # Additional clauses may exist according to API nature
     When the request "{operationId}" is sent
     Then the response status code is 409


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

gplint over `artifacts/testing/*.feature` reported 16 warnings. This PR clears all 16 without adding or removing a single scenario, step, Examples table or tag.

**1. Placeholder syntax (6 warnings, plus consistency)**

Angle brackets are Gherkin's Scenario Outline variable syntax. In `sample-service-template.feature` they were also used for hand-substituted placeholders, in scenarios that *do* have an Examples table — so gplint reported them as variables missing from that table, and a Gherkin runner would try to substitute them. The two conventions sat side by side in the same file — `When the request "<createResource>" is sent` in the happy-path scenarios against `When the request "{operationId}" is sent` in the error scenarios. That is the change this PR needs to make.

The same mixed usage sits in `sample-implicit-events-template.feature` and `event-subscription-template.feature`. It reports nothing today only because those placeholders are in plain scenarios with no Examples table to collide with — the trap springs the moment anyone adds one. Leaving them would also mean two conventions across the templates an API repository copies together, so the same normalisation is applied there for consistency.

The result is a rule that is now checkable: **every remaining angle-bracket token in `artifacts/testing/` is a declared Examples column**, so angle brackets carry exactly one meaning. The genuine Examples variables keep them — `<property>`, `<condition>`, `<required_property>`, `<device_identifier>`, `<oas_spec_schema>`, `<unsupported_credential_type>`.

**2. Duplicate scenario names (10 warnings)**

In `event-subscription-template.feature`, scenarios 12 to 16 carried the names of scenarios 01 and 06. These are additive, not alternatives — a subscription API keeps all of them, so the duplicates propagate into every `*-subscriptions.feature` copied from the template. They now carry the distinction their tags already make (sinkCredential type, provisioning mode).

In `sample-service-template.feature`, "Common validations for any success scenario" appeared six times: three mutually exclusive variants of one scenario, of which an author keeps one, and three different operations. Each now carries a suffix — the variant condition, or the operation. The name is extended rather than replaced, matching how API repositories already distinguish it (for example "… with 3-legs authentication"), so it stays recognisable across the 39 feature files that use it.

Verification: gplint with the tooling-pinned config reports 0 problems. Every commit is line-for-line — the counts of `Scenario`, `Scenario Outline`, `Examples:`, tag lines and table rows are identical before and after.

#### Which issue(s) this PR fixes:

Fixes #682

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Built on top of #678, which normalises line endings in the same files — please merge that one first. Developing from `main` instead would have conflicted with it across all 550 lines of the event subscription template.

Draft while #678 is pending: because this branch is based on #678's head, the diff below currently also contains its commit `05d7158`. Once #678 merges I will rebase onto `main`, and the diff reduces to the three commits described here — already verified by replaying them onto a simulated post-merge `main`.

The three commits are separate on purpose: the required fix, then each consistency file, so they can be reviewed independently.

`event-subscription-template.feature` is the largest diff but the smallest change: one placeholder, `<xxx>`, appears 146 times. Its header already described these as substitution placeholders and now reads "We use `{xxx}` as the subscription resource prefix".

#### Changelog input

```
 release-note
Feature file templates: placeholders use the {…} convention consistently, and duplicate scenario names are made distinct. No scenario, step, Examples table or tag is added or removed.
```

#### Additional documentation

This section can be blank.

```
docs

```
