### PR TITLE
Artifacts Lint: attribute Spectral findings per template and document the expected baseline

### DIFF
--- a/.github/scripts/spectral_annotations.py
+++ b/.github/scripts/spectral_annotations.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Turn per-file Spectral JSON output into check-run annotations and a report.
+
+Used by .github/workflows/artifacts-lint.yml.  The Spectral step lints each
+template in its own invocation (see the workflow header for why) and drops one
+JSON result file per template into a directory; this script merges them into
+the single view a reviewer should see.
+
+What it does, in order:
+
+1. Merge every ``*.json`` result file and deduplicate on
+   ``(source file, line, rule)``.  Findings in ``artifacts/common/**`` are
+   reported once per template that ``$ref``s them, so the raw count is several
+   times the number of real findings.
+2. Split the unique findings into *documented as expected* and *to review*.
+   A finding is expected when its Spectral JSON path matches an entry in the
+   ``suppress_schema_paths`` allowlist of the matching rule in the tooling rule
+   metadata -- the same allowlist, read from the same file, that CAMARA
+   Validation applies in API repositories.
+3. Emit annotations: one per finding to review at its native Spectral severity,
+   plus one ``notice`` per source file summarising that file's expected
+   findings.  GitHub renders at most 10 annotations per level per step, so
+   collapsing the expected baseline keeps the warning level free for findings a
+   pull request actually introduces.
+4. Print a reconciliation report -- raw versus unique counts, per-source-file
+   totals, and every finding to review -- to stdout and to the step summary, so
+   the numbers in the log, in the annotations and on the run page agree.
+
+Exit status is 0 unless the arguments themselves are unusable; the lint outcome
+is the Spectral exit status, which the workflow tracks separately.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+# Spectral DiagnosticSeverity -> GitHub annotation level.  Mirrors OUTPUT_TYPES
+# in @stoplight/spectral-formatters' github-actions formatter, so individually
+# annotated findings keep the level they had before this script existed.
+SEVERITY_TO_LEVEL = {0: "error", 1: "warning", 2: "notice", 3: "notice"}
+
+# Where the expected findings are explained.  Referenced from the aggregate
+# annotations, which name no rule themselves.
+EXPECTED_FINDINGS_DOC = "artifacts/linting_rules/README.md"
+
+# GitHub renders at most this many annotations per level per step.
+ANNOTATION_LIMIT_PER_LEVEL = 10
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--findings-dir",
+        required=True,
+        type=Path,
+        help="directory holding one Spectral JSON result file per linted template",
+    )
+    parser.add_argument(
+        "--rules",
+        required=True,
+        type=Path,
+        help="tooling validation/rules/spectral-rules.yaml (source of the allowlist)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path.cwd(),
+        type=Path,
+        help="repository root, used to make Spectral's absolute paths relative",
+    )
+    parser.add_argument(
+        "--status-file",
+        type=Path,
+        help="optional TSV of '<exit status>\\t<template>' lines, one per invocation",
+    )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        help="optional file to append the report to (normally $GITHUB_STEP_SUMMARY)",
+    )
+    return parser.parse_args(argv)
+
+
+def load_allowlist(rules_path: Path) -> dict[str, tuple[str, ...]]:
+    """Map Spectral rule code -> allowlisted schema paths from rule metadata."""
+    entries = yaml.safe_load(rules_path.read_text(encoding="utf-8")) or []
+    allowlist: dict[str, tuple[str, ...]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("engine") != "spectral":
+            continue
+        paths = entry.get("suppress_schema_paths") or []
+        rule = entry.get("engine_rule")
+        if rule and paths:
+            allowlist[str(rule)] = tuple(str(p) for p in paths)
+    return allowlist
+
+
+def is_expected(schema_path: str, allowed: tuple[str, ...]) -> bool:
+    """Match a schema path against an allowlist the way the post-filter does.
+
+    Exact equality or a prefix ending at a dot boundary, so an entry for
+    ``components.schemas.ErrorInfo`` does not also match a sibling schema named
+    ``ErrorInfoExtended``.
+    """
+    return any(
+        schema_path == entry or schema_path.startswith(entry + ".")
+        for entry in allowed
+    )
+
+
+def relative_to_repo(source: str, repo_root: Path) -> str:
+    """Make an absolute Spectral source path repo-relative, or leave it alone."""
+    if not source:
+        return ""
+    prefix = str(repo_root).rstrip("/") + "/"
+    return source[len(prefix):] if source.startswith(prefix) else source
+
+
+def read_findings(findings_dir: Path, repo_root: Path) -> tuple[list[dict], int]:
+    """Merge the per-invocation JSON files into deduplicated findings.
+
+    Returns the unique findings, ordered by source file then line, and the raw
+    count before deduplication.
+    """
+    raw_count = 0
+    unique: dict[tuple[str, int, str], dict] = {}
+
+    for result_file in sorted(findings_dir.glob("*.json")):
+        text = result_file.read_text(encoding="utf-8").strip()
+        if not text:
+            continue
+        try:
+            results = json.loads(text)
+        except json.JSONDecodeError as exc:
+            print(f"::error::Could not parse {result_file.name}: {exc}")
+            continue
+        if not isinstance(results, list):
+            print(f"::error::Expected a JSON array in {result_file.name}")
+            continue
+
+        for result in results:
+            raw_count += 1
+            start = result.get("range", {}).get("start", {})
+            end = result.get("range", {}).get("end", {})
+            schema_path = ".".join(
+                str(segment) for segment in result.get("path") or []
+            )
+            finding = {
+                "file": relative_to_repo(result.get("source", ""), repo_root),
+                "line": start.get("line", 0) + 1,
+                "column": start.get("character", 0) + 1,
+                "end_line": end.get("line", 0) + 1,
+                "end_column": end.get("character", 0) + 1,
+                "rule": str(result.get("code", "unknown")),
+                "message": result.get("message", ""),
+                "severity": result.get("severity", 1),
+                "schema_path": schema_path,
+            }
+            # Keep the first occurrence: the same common-file finding surfaces
+            # once per template that resolves it.
+            unique.setdefault(
+                (finding["file"], finding["line"], finding["rule"]), finding
+            )
+
+    findings = sorted(unique.values(), key=lambda f: (f["file"], f["line"]))
+    return findings, raw_count
+
+
+def read_failures(status_file: Path | None) -> list[tuple[str, int]]:
+    """Read the templates whose Spectral invocation failed to produce results.
+
+    Exit status 0 (clean) and 1 (findings at or above the fail severity) are
+    both normal; 2 and above is a Spectral runtime error and means that
+    template contributed no findings at all.
+    """
+    if status_file is None or not status_file.is_file():
+        return []
+    failures = []
+    for line in status_file.read_text(encoding="utf-8").splitlines():
+        status, _, template = line.partition("\t")
+        if not template:
+            continue
+        try:
+            code = int(status)
+        except ValueError:
+            continue
+        if code >= 2:
+            failures.append((template, code))
+    return failures
+
+
+def escape_property(value: str) -> str:
+    """Escape a workflow-command property value."""
+    return (
+        value.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
+def escape_message(value: str) -> str:
+    """Escape a workflow-command message body."""
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def emit_annotations(
+    to_review: list[dict],
+    expected_by_file: dict[str, int],
+    failures: list[tuple[str, int]],
+) -> None:
+    """Write the workflow commands that become check-run annotations.
+
+    Findings to review come first so they are the ones that survive the
+    per-level cap if a pull request introduces a large number of them.
+    """
+    for finding in to_review:
+        level = SEVERITY_TO_LEVEL.get(finding["severity"], "warning")
+        params = ",".join(
+            [
+                f"title={escape_property(finding['rule'])}",
+                f"file={escape_property(finding['file'])}",
+                f"col={finding['column']}",
+                f"endColumn={finding['end_column']}",
+                f"line={finding['line']}",
+                f"endLine={finding['end_line']}",
+            ]
+        )
+        print(f"::{level} {params}::{escape_message(finding['message'])}")
+
+    for source_file, count in sorted(expected_by_file.items()):
+        params = ",".join(
+            [
+                "title=Expected lint findings",
+                f"file={escape_property(source_file)}",
+                "line=1",
+            ]
+        )
+        plural = "finding" if count == 1 else "findings"
+        message = (
+            f"{count} {plural} in this file are documented as expected "
+            f"- see {EXPECTED_FINDINGS_DOC}"
+        )
+        print(f"::notice {params}::{escape_message(message)}")
+
+    for template, code in failures:
+        params = ",".join(
+            [
+                "title=Spectral run failed",
+                f"file={escape_property(template)}",
+                "line=1",
+            ]
+        )
+        message = (
+            f"Spectral exited with status {code} for this template, so it "
+            "contributed no findings to the report below."
+        )
+        print(f"::error {params}::{escape_message(message)}")
+
+
+def build_report(
+    findings: list[dict],
+    raw_count: int,
+    expected_keys: set[tuple[str, int, str]],
+    failures: list[tuple[str, int]],
+) -> str:
+    """Render the reconciliation report as Markdown."""
+    to_review = [
+        f for f in findings if (f["file"], f["line"], f["rule"]) not in expected_keys
+    ]
+    expected_count = len(findings) - len(to_review)
+
+    per_file: dict[str, dict[str, int]] = {}
+    for finding in findings:
+        counts = per_file.setdefault(finding["file"], {"expected": 0, "review": 0})
+        key = (finding["file"], finding["line"], finding["rule"])
+        counts["expected" if key in expected_keys else "review"] += 1
+
+    lines = ["## Spectral findings", ""]
+
+    if failures:
+        subject = (
+            "1 template could not be linted"
+            if len(failures) == 1
+            else f"{len(failures)} templates could not be linted"
+        )
+        lines.append(
+            f"**{subject}** - their findings are missing from the counts below:"
+        )
+        lines.append("")
+        for template, code in failures:
+            lines.append(f"- `{template}` (Spectral exit status {code})")
+        lines.append("")
+
+    if not findings:
+        lines.append("No findings.")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append(
+        f"{raw_count} raw findings across the per-template runs reduce to "
+        f"**{len(findings)} unique** findings: **{expected_count} documented as "
+        f"expected**, **{len(to_review)} to review**."
+    )
+    lines.append("")
+    lines.append(
+        "Each template is linted in its own Spectral invocation, so a finding in "
+        "`artifacts/common/**` is reported once per template that `$ref`s it. The "
+        "table below counts each one once, against the file it lives in."
+    )
+    lines.append("")
+    lines.append(
+        "| Source file | Unique findings | Documented as expected | To review |"
+    )
+    lines.append("| --- | --: | --: | --: |")
+    for source_file in sorted(per_file):
+        counts = per_file[source_file]
+        total = counts["expected"] + counts["review"]
+        lines.append(
+            f"| `{source_file}` | {total} | {counts['expected']} | {counts['review']} |"
+        )
+    lines.append(
+        f"| **Total** | **{len(findings)}** | **{expected_count}** | "
+        f"**{len(to_review)}** |"
+    )
+    lines.append("")
+    lines.append(
+        f"Findings documented as expected are explained in "
+        f"`{EXPECTED_FINDINGS_DOC}`; each file above contributing any of them "
+        "carries one `notice` annotation with its count."
+    )
+    lines.append("")
+
+    if to_review:
+        lines.append("### Findings to review")
+        lines.append("")
+        lines.append("| Location | Level | Rule | Message |")
+        lines.append("| --- | --- | --- | --- |")
+        for finding in to_review:
+            level = SEVERITY_TO_LEVEL.get(finding["severity"], "warning")
+            location = f"{finding['file']}:{finding['line']}:{finding['column']}"
+            lines.append(
+                f"| `{location}` | {level} | `{finding['rule']}` | "
+                f"{finding['message']} |"
+            )
+        lines.append("")
+
+        # Say so rather than letting a truncated annotation list read as the
+        # whole result.
+        for level in ("error", "warning"):
+            at_level = sum(
+                1
+                for f in to_review
+                if SEVERITY_TO_LEVEL.get(f["severity"], "warning") == level
+            )
+            if at_level > ANNOTATION_LIMIT_PER_LEVEL:
+                unannotated = at_level - ANNOTATION_LIMIT_PER_LEVEL
+                lines.append(
+                    f"GitHub renders at most {ANNOTATION_LIMIT_PER_LEVEL} "
+                    f"`{level}` annotations per step, so {unannotated} of the "
+                    f"{at_level} `{level}` findings above have no annotation. "
+                    "The table is complete."
+                )
+                lines.append("")
+    else:
+        lines.append("No findings to review.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.findings_dir.is_dir():
+        print(f"::error::Findings directory not found: {args.findings_dir}")
+        return 1
+    if not args.rules.is_file():
+        print(f"::error::Rule metadata not found: {args.rules}")
+        return 1
+
+    allowlist = load_allowlist(args.rules)
+    findings, raw_count = read_findings(args.findings_dir, args.repo_root)
+    failures = read_failures(args.status_file)
+
+    expected_keys = {
+        (f["file"], f["line"], f["rule"])
+        for f in findings
+        if f["schema_path"]
+        and is_expected(f["schema_path"], allowlist.get(f["rule"], ()))
+    }
+    expected_by_file: dict[str, int] = {}
+    to_review = []
+    for finding in findings:
+        if (finding["file"], finding["line"], finding["rule"]) in expected_keys:
+            expected_by_file[finding["file"]] = (
+                expected_by_file.get(finding["file"], 0) + 1
+            )
+        else:
+            to_review.append(finding)
+
+    emit_annotations(to_review, expected_by_file, failures)
+
+    report = build_report(findings, raw_count, expected_keys, failures)
+    print()
+    print(report)
+
+    summary_file = args.summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as handle:
+            handle.write(report)
+            handle.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/artifacts-lint.yml
+++ b/.github/workflows/artifacts-lint.yml
@@ -6,22 +6,30 @@
 #   1. yamllint over all YAML files in artifacts/ - including Github_templates/,
 #      whose installed copies in API repositories are not checked there.
 #   2. Spectral over the full-OpenAPI templates (api-templates/,
-#      notification-templates/) with the CAMARA ruleset of the release line
-#      under development; $ref resolution transitively lints the referenced
-#      common definitions (artifacts/common/).
+#      notification-templates/), one invocation per template, with the CAMARA
+#      ruleset of the release line under development; $ref resolution
+#      transitively lints the referenced common definitions (artifacts/common/).
 #   3. gplint over the Gherkin feature templates (artifacts/testing/).
 #
 # All three checks gate at error level; warnings and hints are reported but do
-# not block. Lint configurations and tool versions are taken from
-# camaraproject/tooling at the same pinned ref API repositories use for CAMARA
-# Validation, so findings here match the validation toolchain - no local
+# not block. Lint configurations, rule metadata and tool versions are taken
+# from camaraproject/tooling at the same pinned ref API repositories use for
+# CAMARA Validation, so findings here match the validation toolchain - no local
 # copies that could drift.
+#
+# The Spectral results of the per-template invocations are merged by
+# .github/scripts/spectral_annotations.py, which deduplicates them, annotates
+# the findings that need review, collapses the findings documented as expected
+# into one notice per file, and reports how the counts reconcile. See that
+# script's docstring for why each part exists.
 #
 # The Spectral ruleset is pinned to the release line main currently targets
 # (r4.x); update SPECTRAL_RULESET when main starts targeting the next line.
 #
 # Changelog:
 # - 2026-07-16: Initial version (yamllint + Spectral + gplint)
+# - 2026-07-29: Spectral runs per template and its results are merged into
+#   attributed annotations plus a reconciled report
 #
 # SEE ALSO: artifacts/linting_rules/README.md
 # =========================================================================================
@@ -69,6 +77,7 @@ jobs:
             validation/package.json
             validation/package-lock.json
             validation/.npmrc
+            validation/rules/spectral-rules.yaml
           sparse-checkout-cone-mode: false
 
       - name: Setup Python
@@ -94,25 +103,53 @@ jobs:
         if: ${{ !cancelled() }}
         run: yamllint -c .tooling/linting/config/.yamllint.yaml -f github artifacts/
 
-      # Findings in transitively referenced common files carry their real
-      # artifacts/common/** paths. The github-actions output goes to a file
-      # first so annotations survive the non-zero exit of the lint command.
+      # One invocation per template, because Spectral loses source attribution
+      # for most findings when several input files share $ref targets
+      # (stoplightio/spectral#2640) - the same bug CAMARA Validation works
+      # around the same way. Findings in transitively referenced common files
+      # then carry their real artifacts/common/** paths.
+      #
+      # Each invocation writes pretty output for the log and JSON for the
+      # annotation step; JSON goes to a file so it survives the non-zero exit
+      # of the lint command. A Spectral runtime error (exit status 2 or above)
+      # on one template does not stop the others - the step reports what the
+      # remaining templates found and then fails.
       - name: Spectral over API and notification templates
         if: ${{ !cancelled() }}
         env:
           NODE_PATH: ${{ github.workspace }}/.tooling/validation/node_modules
         run: |
           export PATH="${{ github.workspace }}/.tooling/validation/node_modules/.bin:${PATH}"
+          results="${RUNNER_TEMP}/spectral-results"
+          mkdir -p "${results}"
+          shopt -s nullglob
+          templates=(artifacts/api-templates/*.yaml artifacts/notification-templates/*.yaml)
+          shopt -u nullglob
+          if [ ${#templates[@]} -eq 0 ]; then
+            echo "::error::No templates matched - nothing was linted"
+            exit 1
+          fi
           status=0
-          spectral lint \
-            --ruleset ".tooling/linting/config/${SPECTRAL_RULESET}" \
-            --fail-severity error \
-            -f pretty -f github-actions \
-            -o.pretty /dev/stdout \
-            -o.github-actions "${RUNNER_TEMP}/spectral-annotations.log" \
-            artifacts/api-templates/*.yaml artifacts/notification-templates/*.yaml \
-            || status=$?
-          cat "${RUNNER_TEMP}/spectral-annotations.log"
+          for template in "${templates[@]}"; do
+            # Path-derived so two templates of the same name in different
+            # directories cannot overwrite each other's results.
+            name="${template//\//-}"
+            rc=0
+            spectral lint \
+              --ruleset ".tooling/linting/config/${SPECTRAL_RULESET}" \
+              --fail-severity error \
+              -f pretty -f json \
+              -o.pretty /dev/stdout \
+              -o.json "${results}/${name}.json" \
+              "${template}" \
+              || rc=$?
+            printf '%s\t%s\n' "${rc}" "${template}" >> "${results}/status.tsv"
+            if [ "${rc}" -gt "${status}" ]; then status=$rc; fi
+          done
+          python3 .github/scripts/spectral_annotations.py \
+            --findings-dir "${results}" \
+            --rules .tooling/validation/rules/spectral-rules.yaml \
+            --status-file "${results}/status.tsv"
           exit $status
 
       # gplint exits non-zero only on error-level findings; warnings are

--- a/artifacts/linting_rules/README.md
+++ b/artifacts/linting_rules/README.md
@@ -8,9 +8,48 @@ The [Artifacts Lint workflow](../../.github/workflows/artifacts-lint.yml) runs o
 - **Spectral** over the full-OpenAPI templates (`api-templates/`, `notification-templates/`) with the CAMARA ruleset of the release line under development; `$ref` resolution transitively checks the referenced definitions in `common/`
 - **gplint** over the Gherkin feature templates (`testing/`)
 
-Lint configurations and tool versions are taken from the [tooling repository](https://github.com/camaraproject/tooling/tree/main/linting/config) at the same pinned ref API repositories use for CAMARA Validation, so findings here match the validation toolchain.
+Lint configurations, rule metadata and tool versions are taken from the [tooling repository](https://github.com/camaraproject/tooling/tree/main/linting) at the same pinned ref API repositories use for CAMARA Validation, so findings here match the validation toolchain.
 
-All three checks block only on error-level findings; warnings and hints are reported in the workflow log but do not fail the check.
+All three checks block only on error-level findings; warnings and hints are reported but do not fail the check.
+
+Each template is linted in its own Spectral invocation, because Spectral loses the source file of most findings when several input files share `$ref` targets ([stoplightio/spectral#2640](https://github.com/stoplightio/spectral/issues/2640)). A finding in `common/` is therefore reported once per template that references it, and the raw count in the per-template log output is several times the number of distinct findings. The step reconciles the two in a table it writes both to the log and to the run summary.
+
+### Expected lint findings
+
+Artifacts in this repository are held to the same standard as API definitions: fix a finding, or document why it stays. The findings below are the documented baseline — they are expected, and a pull request is not asked to resolve them. Anything a check reports beyond this list was introduced by the change under review.
+
+Findings in this list that are recorded as known-unactionable in the CAMARA Validation rule metadata are collapsed by the workflow into a single `notice` annotation per file, pointing back at this section. The remainder keep an individual annotation, so they stay visible until they are resolved.
+
+#### Spectral: `owasp:api4:2023-string-restricted`
+
+Fifteen findings, all of the same kind: a string field that already constrains its length via `maxLength` but has no `format`, `pattern`, `enum` or `const`, because none of those would carry meaning for a free-text or externally-defined identifier value.
+
+Ten of them — the `common/` fields other than the pagination `Link` header — are listed in the `suppress_schema_paths` allowlist of rule S-313 in the [tooling rule metadata](https://github.com/camaraproject/tooling/blob/main/validation/rules/spectral-rules.yaml), which is where API repositories already suppress them. The workflow reads that allowlist directly rather than keeping a copy, so this list and CAMARA Validation cannot drift apart. The allowlist names individual fields rather than whole schemas, so a newly added unconstrained string in a common schema still surfaces on its own and can be judged on its own merits.
+
+| Field | Annotation |
+| --- | --- |
+| `common/CAMARA_common.yaml` → `components.headers.link.schema` | individual |
+| `common/CAMARA_common.yaml` → `components.schemas.ErrorInfo.properties.code` | collapsed |
+| `common/CAMARA_common.yaml` → `components.schemas.ErrorInfo.properties.message` | collapsed |
+| `common/CAMARA_common.yaml` → `components.schemas.NetworkAccessIdentifier` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.CloudEvent.properties.id` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.CloudEvent.properties.type` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.SubscriptionId` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.HTTPSettings.properties.headers.additionalProperties` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.SubscriptionStarted.properties.initiationDescription` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.SubscriptionUpdated.properties.updateDescription` | collapsed |
+| `common/CAMARA_event_common.yaml` → `components.schemas.SubscriptionEnded.properties.terminationDescription` | collapsed |
+| `api-templates/sample-service.yaml` → `components.schemas.CreateResource.properties.name` | individual |
+| `api-templates/sample-service.yaml` → `components.schemas.Resource.properties.name` | individual |
+| `api-templates/sample-implicit-events.yaml` → `components.schemas.CreateResource.properties.name` | individual |
+| `api-templates/sample-implicit-events.yaml` → `components.schemas.Resource.properties.name` | individual |
+
+The two groups that are annotated individually are the ones not covered by the allowlist:
+
+- The pagination `Link` header in `CAMARA_common.yaml` holds an RFC 8288 header value, which has a defined syntax but no OpenAPI `format` for it. Adding it to the S-313 allowlist is tracked in [camaraproject/tooling#401](https://github.com/camaraproject/tooling/issues/401); once that lands the workflow collapses it with the rest, with no change needed here.
+- The `name` fields of the sample resources in the API templates are placeholder content of the templates themselves, not part of the common library, so they are outside the scope of an allowlist meant for `common/`.
+
+The scope of the OWASP string rules is discussed more broadly in [#596](https://github.com/camaraproject/Commonalities/issues/596); this section records the current state and follows whatever that discussion resolves.
 
 ### When a check fails
 


### PR DESCRIPTION
#### What type of PR is this?

* bug

#### What this PR does / why we need it:

The Spectral step of the Artifacts Lint workflow (#673) linted all four templates in one invocation. Spectral loses the source file of most findings when several input documents share `$ref` targets ([stoplightio/spectral#2640](https://github.com/stoplightio/spectral/issues/2640)), so the step reported 9 problems in its summary, emitted 152 `::warning` lines, and produced 10 annotations of which 3 pointed at `.` line 1 — while the two real findings in `api-templates/sample-service.yaml` had no annotation at all. Details and the reproduction in #684.

Spectral now runs **once per template** and the results are merged, which is what CAMARA Validation already does for the same reason. Six findings that the old view hid become visible, and the log, the annotations and the summary now describe one set of 15 findings instead of three different numbers:

- `.github/scripts/spectral_annotations.py` merges the per-template JSON, deduplicates on `(file, line, rule)`, emits the annotations, and prints a reconciliation table to the log and to the run summary.
- The 10 findings that are the documented common-library baseline are collapsed into one `notice` annotation per source file, pointing at `artifacts/linting_rules/README.md`. The remaining 5 keep an individual annotation at their native severity.
- The allowlist behind that split is read from `validation/rules/spectral-rules.yaml` in `camaraproject/tooling` (rule S-313 `suppress_schema_paths`) — added to the existing sparse-checkout rather than copied, so it cannot drift from what API repositories apply. Matching replicates the tooling semantics, including the dot-boundary prefix rule, so a newly added unconstrained string in a common schema still surfaces on its own.

Annotation budget, per step: **5 of 10 warning slots** used, plus 2 notices — against 10 of 10 consumed by the baseline before this change, where a warning introduced by a pull request could go unannotated.

`artifacts/linting_rules/README.md` gains the expected-findings section from #676: all 15 findings with their rationale, keyed on schema path rather than line number so it does not go stale, and marked collapsed or individual so it can be checked against what the workflow actually annotates.

#### Which issue(s) this PR fixes:

Fixes #684
Fixes #676

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

- The two halves are mutually dependent: the aggregate annotation points at the README section, and the section's baseline is the corrected 15-finding set — so they are reviewable only together.
- All numbers were reproduced against `main` with the pinned toolchain (Spectral 6.16.2, `.spectral-r4.yaml`): 152 raw results with 9 sourced for one invocation over four templates, versus 26 raw results with none unsourced and 15 unique for one invocation per template.
- Bare Spectral reads no rule metadata, so the 15-finding baseline is irreducible here: [camaraproject/tooling#401](https://github.com/camaraproject/tooling/issues/401) will not change what this CI shows. Under this change, however, the pagination `Link` header finding stops being annotated individually the moment camaraproject/tooling#401 lands, with no edit needed in this repository.
- Two groups from #676 need no documentation: the 9 `oas3-unused-component` findings are gone since tooling made unused-component detection discriminator-aware, and the gplint findings are being fixed (#682, via #683) rather than documented as expected. The section therefore covers Spectral only.
- Verified on a dispatched run before this PR ([hdamker/Commonalities run 30483686070](https://github.com/hdamker/Commonalities/actions/runs/30483686070)): the Spectral step produces 5 warning annotations at the five locations listed in the README section plus 2 `notice` aggregates, and no annotation points at `.` line 1.
- A Spectral runtime error on one template no longer hides the other three: the step reports what the rest found, annotates the failed template, and then fails.

#### Changelog input

```
 release-note
- Artifacts Lint: Spectral runs per template so findings keep their source file; annotations now cover the findings that need review, the documented baseline is collapsed into one notice per file, and the log and run summary report one reconciled count
- Documented the expected lint findings of the artifacts in artifacts/linting_rules/README.md
```

#### Additional documentation

```
docs
artifacts/linting_rules/README.md — new "Expected lint findings" section
```
