### PR TITLE
Rewording `perPage` description in CAMARA_common.yaml

### DIFF
--- a/artifacts/common/CAMARA_common.yaml
+++ b/artifacts/common/CAMARA_common.yaml
@@ -80,7 +80,7 @@ components:
       name: perPage
       in: query
       description: >
-        Number of subscriptions to return per page.
+        Number of resources to return per page.
         Values outside the allowed range are rejected with `400 INVALID_ARGUMENT`.
       required: false
       schema:


### PR DESCRIPTION
#### What type of PR is this?

* correction
#### What this PR does / why we need it:
The `perPage` query parameter in `CAMARA_common.yaml` ([artifacts/common/CAMARA_common.yaml#L77-L83](https://github.com/camaraproject/Commonalities/blob/main/artifacts/common/CAMARA_common.yaml#L77-L83)) is described as:

> Number of subscriptions to return per page.

`perPage` is the common pagination parameter for any paginated list operation, not just subscriptions.

This PR aligns the description with API Design Guide wording (§4.1.1):
```
Number of resources to return per page.

```
#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #681 


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:



#### Changelog input

```
Corrected  `perPage` description in CAMARA_common.yaml

```
