### PR TITLE
Fix Spectral artifact finding attribution

### DIFF
--- a/.github/workflows/artifacts-lint.yml
+++ b/.github/workflows/artifacts-lint.yml
@@ -22,6 +22,8 @@
 #
 # Changelog:
 # - 2026-07-16: Initial version (yamllint + Spectral + gplint)
+# - 2026-07-30: Preserve Spectral attribution with per-template runs and
+#               collapse the documented S-313 common-library baseline.
 #
 # SEE ALSO: artifacts/linting_rules/README.md
 # =========================================================================================
@@ -69,6 +71,7 @@ jobs:
             validation/package.json
             validation/package-lock.json
             validation/.npmrc
+            validation/rules/spectral-rules.yaml
           sparse-checkout-cone-mode: false
 
       - name: Setup Python
@@ -84,6 +87,9 @@ jobs:
       - name: Install yamllint (tooling-pinned version)
         run: pip install --quiet -r .tooling/requirements.txt
 
+      - name: Test Spectral report formatter
+        run: python -B scripts/test_report_spectral_findings.py
+
       - name: Install Spectral and gplint (tooling-pinned versions)
         run: npm ci --ignore-scripts
         working-directory: .tooling/validation
@@ -94,25 +100,44 @@ jobs:
         if: ${{ !cancelled() }}
         run: yamllint -c .tooling/linting/config/.yamllint.yaml -f github artifacts/
 
-      # Findings in transitively referenced common files carry their real
-      # artifacts/common/** paths. The github-actions output goes to a file
-      # first so annotations survive the non-zero exit of the lint command.
+      # Spectral loses source attribution when multiple input documents share
+      # $ref targets (stoplightio/spectral#2640), so invoke it once per
+      # template. The formatter deduplicates shared findings and collapses the
+      # documented S-313 common-library baseline into notices.
       - name: Spectral over API and notification templates
         if: ${{ !cancelled() }}
         env:
           NODE_PATH: ${{ github.workspace }}/.tooling/validation/node_modules
         run: |
           export PATH="${{ github.workspace }}/.tooling/validation/node_modules/.bin:${PATH}"
+          results_dir="${RUNNER_TEMP}/spectral-results"
+          rm -rf "${results_dir}"
+          mkdir -p "${results_dir}"
+
           status=0
-          spectral lint \
-            --ruleset ".tooling/linting/config/${SPECTRAL_RULESET}" \
-            --fail-severity error \
-            -f pretty -f github-actions \
-            -o.pretty /dev/stdout \
-            -o.github-actions "${RUNNER_TEMP}/spectral-annotations.log" \
-            artifacts/api-templates/*.yaml artifacts/notification-templates/*.yaml \
-            || status=$?
-          cat "${RUNNER_TEMP}/spectral-annotations.log"
+          index=0
+          for template in artifacts/api-templates/*.yaml artifacts/notification-templates/*.yaml; do
+            output="${results_dir}/spectral-${index}.json"
+            if spectral lint \
+              --ruleset ".tooling/linting/config/${SPECTRAL_RULESET}" \
+              --fail-severity error \
+              --format json \
+              --output "${output}" \
+              "${template}"; then
+              :
+            else
+              spectral_status=$?
+              if (( spectral_status > status )); then
+                status=$spectral_status
+              fi
+            fi
+            index=$((index + 1))
+          done
+
+          python -B scripts/report_spectral_findings.py \
+            --metadata .tooling/validation/rules/spectral-rules.yaml \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            "${results_dir}"/*.json
           exit $status
 
       # gplint exits non-zero only on error-level findings; warnings are

--- a/artifacts/linting_rules/README.md
+++ b/artifacts/linting_rules/README.md
@@ -10,6 +10,8 @@ The [Artifacts Lint workflow](../../.github/workflows/artifacts-lint.yml) runs o
 
 Lint configurations and tool versions are taken from the [tooling repository](https://github.com/camaraproject/tooling/tree/main/linting/config) at the same pinned ref API repositories use for CAMARA Validation, so findings here match the validation toolchain.
 
+Spectral runs once per template to preserve source attribution for findings in shared `$ref` targets, then deduplicates findings by file, line, and rule. Known S-313 findings that match the tooling metadata's `suppress_schema_paths` allowlist are summarized as one notice per common file; all other findings retain their individual Spectral severity.
+
 All three checks block only on error-level findings; warnings and hints are reported in the workflow log but do not fail the check.
 
 ### When a check fails

--- a/scripts/report_spectral_findings.py
+++ b/scripts/report_spectral_findings.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Deduplicate per-template Spectral output and emit GitHub annotations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+Finding = dict[str, Any]
+
+SPECTRAL_LEVELS = {
+    0: ("error", "error"),
+    1: ("warning", "warning"),
+    2: ("info", "notice"),
+    3: ("hint", "notice"),
+}
+S_313_ID = "S-313"
+S_313_METADATA_URL = (
+    "https://github.com/camaraproject/tooling/blob/v1-rc/"
+    "validation/rules/spectral-rules.yaml"
+)
+
+
+def _start(finding: Finding) -> dict[str, Any]:
+    value = finding.get("range", {}).get("start", {})
+    return value if isinstance(value, dict) else {}
+
+
+def finding_line(finding: Finding) -> int:
+    return int(_start(finding).get("line", 0)) + 1
+
+
+def finding_column(finding: Finding) -> int | None:
+    character = _start(finding).get("character")
+    return int(character) + 1 if character is not None else None
+
+
+def schema_path(finding: Finding) -> str:
+    value = finding.get("path")
+    if not isinstance(value, list):
+        return ""
+    return ".".join(str(segment) for segment in value)
+
+
+def normalize_source(source: object, repo_root: Path) -> str:
+    if not isinstance(source, str) or not source:
+        raise ValueError("Spectral finding is missing source attribution")
+
+    path = Path(source)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(repo_root.resolve())
+        except ValueError as exc:
+            raise ValueError(f"Spectral source is outside the repository: {source}") from exc
+    return path.as_posix()
+
+
+def load_findings(result_paths: list[Path], repo_root: Path) -> list[Finding]:
+    """Load, normalize, and deduplicate findings by file, line, and rule."""
+    findings: list[Finding] = []
+    seen: set[tuple[str, int, str]] = set()
+
+    for result_path in result_paths:
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise ValueError(f"Spectral output is not an array: {result_path}")
+
+        for raw in data:
+            if not isinstance(raw, dict):
+                raise ValueError(f"Spectral output contains a non-object: {result_path}")
+            finding = dict(raw)
+            finding["source"] = normalize_source(finding.get("source"), repo_root)
+            key = (
+                finding["source"],
+                finding_line(finding),
+                str(finding.get("code", "")),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(finding)
+
+    return sorted(
+        findings,
+        key=lambda finding: (
+            finding["source"],
+            finding_line(finding),
+            str(finding.get("code", "")),
+        ),
+    )
+
+
+def load_s_313_allowlist(metadata_path: Path) -> tuple[str, set[str]]:
+    metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    if not isinstance(metadata, list):
+        raise ValueError("Spectral rule metadata is not a list")
+
+    rule = next(
+        (item for item in metadata if isinstance(item, dict) and item.get("id") == S_313_ID),
+        None,
+    )
+    if rule is None:
+        raise ValueError(f"{S_313_ID} is missing from Spectral rule metadata")
+
+    engine_rule = rule.get("engine_rule")
+    allowlist = rule.get("suppress_schema_paths")
+    if not isinstance(engine_rule, str) or not isinstance(allowlist, list):
+        raise ValueError(f"{S_313_ID} metadata is missing its engine rule or allowlist")
+    return engine_rule, {str(path) for path in allowlist}
+
+
+def partition_allowlisted_findings(
+    findings: list[Finding],
+    engine_rule: str,
+    allowlist: set[str],
+) -> tuple[dict[str, list[Finding]], list[Finding]]:
+    grouped: dict[str, list[Finding]] = defaultdict(list)
+    individual: list[Finding] = []
+
+    for finding in findings:
+        if finding.get("code") == engine_rule and schema_path(finding) in allowlist:
+            grouped[finding["source"]].append(finding)
+        else:
+            individual.append(finding)
+    return dict(grouped), individual
+
+
+def _escape_data(value: object) -> str:
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_property(value: object) -> str:
+    return _escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
+def _count_label(count: int, singular: str, plural: str | None = None) -> str:
+    return f"{count} {singular if count == 1 else plural or singular + 's'}"
+
+
+def emit_annotation(
+    level: str,
+    finding: Finding,
+    title: str,
+    message: str,
+) -> None:
+    properties = [
+        f"file={_escape_property(finding['source'])}",
+        f"line={finding_line(finding)}",
+        f"title={_escape_property(title)}",
+    ]
+    column = finding_column(finding)
+    if column is not None:
+        properties.insert(2, f"col={column}")
+    print(f"::{level} {','.join(properties)}::{_escape_data(message)}")
+
+
+def render_report(
+    findings: list[Finding],
+    grouped: dict[str, list[Finding]],
+    individual: list[Finding],
+    input_count: int,
+) -> None:
+    for finding in findings:
+        severity = int(finding.get("severity", 1))
+        label = SPECTRAL_LEVELS.get(severity, ("warning", "warning"))[0]
+        column = finding_column(finding)
+        location = f"{finding['source']}:{finding_line(finding)}"
+        if column is not None:
+            location += f":{column}"
+        print(
+            f"{location} {label} {finding.get('message', '')} "
+            f"{finding.get('code', 'unknown')}"
+        )
+
+    counts = Counter(int(finding.get("severity", 1)) for finding in findings)
+    print(
+        f"\nX {len(findings)} problems "
+        f"({_count_label(counts[0], 'error')}, "
+        f"{_count_label(counts[1], 'warning')}, "
+        f"{_count_label(counts[2], 'info', 'infos')}, "
+        f"{_count_label(counts[3], 'hint')})"
+    )
+
+    collapsed_count = 0
+    for source, source_findings in sorted(grouped.items()):
+        collapsed_count += len(source_findings)
+        first = min(source_findings, key=finding_line)
+        emit_annotation(
+            "notice",
+            first,
+            f"{S_313_ID} documented baseline",
+            (
+                f"{len(source_findings)} expected {S_313_ID} findings match "
+                f"suppress_schema_paths and are collapsed here. {S_313_METADATA_URL}"
+            ),
+        )
+
+    for finding in individual:
+        severity = int(finding.get("severity", 1))
+        annotation_level = SPECTRAL_LEVELS.get(severity, ("warning", "warning"))[1]
+        emit_annotation(
+            annotation_level,
+            finding,
+            str(finding.get("code", "Spectral")),
+            str(finding.get("message", "")),
+        )
+
+    print(
+        f"Spectral reported {len(findings)} unique findings across {input_count} templates: "
+        f"{len(individual)} individual annotations and {len(grouped)} notices "
+        f"covering {collapsed_count} documented baseline findings."
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("results", type=Path, nargs="+")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    findings = load_findings(args.results, args.repo_root)
+    engine_rule, allowlist = load_s_313_allowlist(args.metadata)
+    grouped, individual = partition_allowlisted_findings(findings, engine_rule, allowlist)
+    render_report(findings, grouped, individual, len(args.results))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_report_spectral_findings.py
+++ b/scripts/test_report_spectral_findings.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for the Spectral annotation formatter."""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from report_spectral_findings import (
+    load_findings,
+    load_s_313_allowlist,
+    partition_allowlisted_findings,
+    render_report,
+)
+
+
+def finding(
+    source: Path | None,
+    line: int,
+    schema_path: list[str],
+    *,
+    code: str = "owasp:api4:2023-string-restricted",
+    severity: int = 1,
+) -> dict[str, object]:
+    value: dict[str, object] = {
+        "code": code,
+        "severity": severity,
+        "message": "Constrain this string.",
+        "path": schema_path,
+        "range": {"start": {"line": line - 1, "character": 3}},
+    }
+    if source is not None:
+        value["source"] = str(source)
+    return value
+
+
+class SpectralReportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.metadata = self.root / "spectral-rules.yaml"
+        self.metadata.write_text(
+            """
+- id: S-313
+  engine_rule: "owasp:api4:2023-string-restricted"
+  suppress_schema_paths:
+    - components.schemas.ErrorInfo.properties.code
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write_results(self, name: str, values: list[dict[str, object]]) -> Path:
+        path = self.root / name
+        path.write_text(json.dumps(values), encoding="utf-8")
+        return path
+
+    def test_load_findings_normalizes_and_deduplicates(self) -> None:
+        source = self.root / "artifacts/common/CAMARA_common.yaml"
+        duplicate = finding(
+            source,
+            10,
+            ["components", "schemas", "ErrorInfo", "properties", "code"],
+        )
+        first = self.write_results("first.json", [duplicate])
+        second = self.write_results("second.json", [duplicate])
+
+        findings = load_findings([first, second], self.root)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["source"], "artifacts/common/CAMARA_common.yaml")
+
+    def test_load_findings_rejects_missing_source(self) -> None:
+        result = self.write_results(
+            "missing-source.json",
+            [finding(None, 1, ["components", "schemas", "Example"])],
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing source attribution"):
+            load_findings([result], self.root)
+
+    def test_render_groups_only_allowlisted_schema_paths(self) -> None:
+        common_source = self.root / "artifacts/common/CAMARA_common.yaml"
+        template_source = self.root / "artifacts/api-templates/sample-service.yaml"
+        result = self.write_results(
+            "results.json",
+            [
+                finding(
+                    common_source,
+                    10,
+                    ["components", "schemas", "ErrorInfo", "properties", "code"],
+                ),
+                finding(
+                    common_source,
+                    20,
+                    ["components", "headers", "link", "schema"],
+                ),
+                finding(
+                    template_source,
+                    30,
+                    ["components", "schemas", "Resource", "properties", "name"],
+                ),
+                finding(
+                    template_source,
+                    40,
+                    ["openapi"],
+                    code="oas3-schema",
+                    severity=0,
+                ),
+            ],
+        )
+        findings = load_findings([result], self.root)
+        engine_rule, allowlist = load_s_313_allowlist(self.metadata)
+        grouped, individual = partition_allowlisted_findings(
+            findings,
+            engine_rule,
+            allowlist,
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            render_report(findings, grouped, individual, input_count=1)
+        rendered = output.getvalue()
+
+        self.assertEqual(sum(map(len, grouped.values())), 1)
+        self.assertEqual(len(individual), 3)
+        self.assertEqual(rendered.count("::notice "), 1)
+        self.assertEqual(rendered.count("::warning "), 2)
+        self.assertEqual(rendered.count("::error "), 1)
+        self.assertIn("title=owasp%3Aapi4%3A2023-string-restricted", rendered)
+        self.assertIn("X 4 problems (1 error, 3 warnings, 0 infos, 0 hints)", rendered)
+        self.assertIn("3 individual annotations and 1 notices covering 1", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

The Artifacts Lint workflow currently passes all four templates to one Spectral invocation. Shared `$ref` targets trigger stoplightio/spectral#2640, producing 152 results with 143 missing their source and hiding six genuine findings from the reported subset.

This runs Spectral once per template and deduplicates the JSON results by file, line, and rule. The formatter reads the pinned S-313 `suppress_schema_paths` metadata, summarizes the ten documented common-library findings as two notices, and leaves the other five findings as individual warnings at their real source locations. The resulting log and annotations consistently account for all 15 unique findings.

#### Which issue(s) this PR fixes:

Fixes #684

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

The formatter tests cover source normalization, duplicate suppression, allowlist-only grouping, native severity mapping, and GitHub annotation escaping. The workflow continues to block only on error-level findings.

#### Changelog input

```
Fix Spectral source attribution and annotation accounting in the common-artifact lint workflow.
```

#### Additional documentation

The artifacts linting README now documents per-template Spectral execution, deduplication, and S-313 baseline notices.
