### PR TITLE
docs: correct initial API version placeholder

### DIFF
--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -1419,7 +1419,7 @@ servers:
 
 ---
 
-IMPORTANT: CAMARA public APIs with x=0 (`v0.y.z`) MUST use both the MAJOR and the MINOR version number separated by a dot (".") in the API version in the `url` field: `v0.y`.
+IMPORTANT: CAMARA public APIs with x=0 (`v0.y.z`) MUST use both the MAJOR and the MINOR version numbers separated by a dot (".") in the API version in the `url` field: `v0.y`.
 
 ---
 

--- a/documentation/CAMARA-API-Design-Guide.md
+++ b/documentation/CAMARA-API-Design-Guide.md
@@ -1419,7 +1419,7 @@ servers:
 
 ---
 
-IMPORTANT: CAMARA public APIs with x=0 (`v0.x.y`) MUST use both the MAJOR and the MINOR version number separated by a dot (".") in the API version in the `url` field: `v0.y`.
+IMPORTANT: CAMARA public APIs with x=0 (`v0.y.z`) MUST use both the MAJOR and the MINOR version number separated by a dot (".") in the API version in the `url` field: `v0.y`.
 
 ---
 


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Corrects the full initial API version placeholder from `v0.x.y` to `v0.y.z` in the URL-versioning guidance. For APIs where the major version is zero, `y` and `z` represent the minor and patch components, while the URL remains abbreviated as `v0.y`.

#### Which issue(s) this PR fixes:

Fixes #703

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Documentation-only correction; no API behavior or artifact changes.

#### Changelog input

```
release-note
Correct the initial API version placeholder in the API Design Guide.
```

#### Additional documentation

```
docs
Correct the initial API version placeholder in the URL-versioning guidance.
```