### PR TITLE
feat: add scheduled caller for CommonalitiesTest regression sweep

### DIFF
--- a/.github/workflows/commonalities-regression.yml
+++ b/.github/workflows/commonalities-regression.yml
@@ -1,0 +1,33 @@
+# Commonalities Regression Testing (canary) — scheduled trigger
+#
+# Scheduled sync/cherry-pick/sweep against camaraproject/CommonalitiesTest,
+# calling tooling's reusable pipeline. See CommonalitiesTest's README for
+# what this tests and why:
+# https://github.com/camaraproject/CommonalitiesTest#readme
+#
+# tooling keeps its own dispatch-only caller of the same reusable workflow
+# for ad hoc runs; this is the only scheduled trigger.
+
+name: Commonalities Regression
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: >-
+          Force the sweep to run even if neither the common nor the
+          templates diff fired (e.g. to re-confirm a fixture after a
+          manual recapture).
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  sync-and-sweep:
+    name: CommonalitiesTest
+    uses: camaraproject/tooling/.github/workflows/commonalities-regression-sync.yml@main
+    with:
+      force: ${{ inputs.force || false }}
+    secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Adds the scheduled trigger for CommonalitiesTest's regression sweep —
a standing validation signal on unreleased Commonalities content,
running daily against real API-repository layouts. See
CommonalitiesTest's README for what it tests and why:
https://github.com/camaraproject/CommonalitiesTest#readme

The sync/cherry-pick/sweep pipeline itself stays in
camaraproject/tooling; this just moves the schedule's home there to
here, alongside a companion PR on tooling that drops it from tooling's
own caller (kept for ad hoc dispatch only).

#### Which issue(s) this PR fixes:

Part of #706

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

No change to Commonalities' own API content or any other workflow.

#### Changelog input

```
 release-note

NONE
```

#### Additional documentation 

This section can be blank.



```
docs

```